### PR TITLE
Add convert methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ class.
 - [The Convert Methods](#the-convert-methods)
   - [To TrueClass / FalseClass](#to-trueclass--falseclass-1)
   - [To Proper Class](#to-proper-class)
+  - [Newlines To Characters](#newlines-to-characters)
 - [The Like Methods](#the-like-methods)
   - [Like Integer](#like-integer)
   - [Like Float](#like-float)
@@ -221,6 +222,23 @@ Also this returns nil when a string is an empty string.
 'false'.to_pretty #=> false
 
 ''.to_pretty #=> nil
+```
+
+### Newlines To Characters
+`nl_to` method is to convert from a string has newlines to specific characters.
+`nl2` method is alias for `nl_to` .
+
+```ruby
+"Hi!\nWe are Brushdown.".nl_to(' / ') #=> 'Hi! / We are Brushdown.'
+"Hi!\nWe are Brushdown.".nl2(' / ')   #=> 'Hi! / We are Brushdown.'
+```
+
+`nl_to_br` method is to convert from a string has newlines to a HTML tag `<br>`
+for break line. `nl2br` method is alias for `nl_to_br` .
+
+```ruby
+"Hi!\nWe are Brushdown.".nl_to_br #=> 'Hi!<br>We are Brushdown.'
+"Hi!\nWe are Brushdown.".nl2br    #=> 'Hi!<br>We are Brushdown.'
 ```
 
 

--- a/lib/string_foundation/convert.rb
+++ b/lib/string_foundation/convert.rb
@@ -35,4 +35,15 @@ class String
     (self.length > 0) ? self : nil
   end
 
+  # Convert from newline character to specific characters.
+  def nl_to(char)
+    char = '' if char.nil?
+    self.gsub(/(\r\n|\n)/, char)
+  end
+
+  # Convert from newline character to a HTML tag "<br>".
+  def nl_to_br
+    self.nl_to('<br>')
+  end
+
 end

--- a/lib/string_foundation/convert.rb
+++ b/lib/string_foundation/convert.rb
@@ -46,4 +46,6 @@ class String
     self.nl_to('<br>')
   end
 
+  alias_method :nl2, :nl_to
+  alias_method :nl2br, :nl_to_br
 end

--- a/spec/string_foundation/convert_spec.rb
+++ b/spec/string_foundation/convert_spec.rb
@@ -162,4 +162,73 @@ describe '[ Convert Methods ]' do
     end
   end
 
+
+  # ----------------------------------------------------------------------------
+  # Convert From Newline To Characters
+  # ----------------------------------------------------------------------------
+  describe 'CONVERT FROM NEWLINE TO CHARACTERS' do
+    let(:string) { "We are Brushdown.\nWe are Brushdown." }
+    let(:char) { '<br>' }
+    subject { string.nl_to(char) }
+
+    context 'when a string has newlines "\n",' do
+      it { is_expected.to eq 'We are Brushdown.<br>We are Brushdown.' }
+    end
+
+    context 'when a string has newlines "\r\n",' do
+      let(:string) { "We are Brushdown.\r\nWe are Brushdown." }
+
+      it { is_expected.to eq 'We are Brushdown.<br>We are Brushdown.' }
+    end
+
+    context 'when a string does not have newlines,' do
+      let(:string) { "We are Brushdown. We are Brushdown." }
+
+      it { is_expected.to eq string }
+    end
+
+    context 'when an argument is not set,' do
+      subject { string.nl_to() }
+
+      it { is_expected_as_block.to raise_error(ArgumentError) }
+    end
+
+    context 'when an argument is nil,' do
+      let(:char) { nil }
+
+      it { is_expected.to eq 'We are Brushdown.We are Brushdown.' }
+    end
+
+    context 'when an argument is an empty string,' do
+      let(:char) { '' }
+
+      it { is_expected.to eq 'We are Brushdown.We are Brushdown.' }
+    end
+  end
+
+
+  # ----------------------------------------------------------------------------
+  # Convert From Newline To <br>
+  # ----------------------------------------------------------------------------
+  describe 'CONVERT FROM NEWLINE TO `<br>`' do
+    let(:string) { "We are Brushdown.\nWe are Brushdown." }
+    subject { string.nl_to_br }
+
+    context 'when a string has newlines "\n",' do
+      it { is_expected.to eq 'We are Brushdown.<br>We are Brushdown.' }
+    end
+
+    context 'when a string has newlines "\r\n",' do
+      let(:string) { "We are Brushdown.\r\nWe are Brushdown." }
+
+      it { is_expected.to eq 'We are Brushdown.<br>We are Brushdown.' }
+    end
+
+    context 'when a string does not have newlines,' do
+      let(:string) { "We are Brushdown. We are Brushdown." }
+
+      it { is_expected.to eq string }
+    end
+  end
+
 end


### PR DESCRIPTION
Add `nl_to` and `nl_to_br` methods to convert from a string has newlines to specific characters or a HTML tag `<br>` . Also add alias methods `nl2` and `nl2br` for `nl_to` and `nl_to_br` .

```ruby
"Hi!\nWe are Brushdown.".nl_to(' / ') #=> 'Hi! / We are Brushdown.'
"Hi!\nWe are Brushdown.".nl2(' / ')   #=> 'Hi! / We are Brushdown.'

"Hi!\nWe are Brushdown.".nl_to_br #=> 'Hi!<br>We are Brushdown.'
"Hi!\nWe are Brushdown.".nl2br    #=> 'Hi!<br>We are Brushdown.'
```