### PR TITLE
Use a method "be_nil" instead of "eq(nil)"

### DIFF
--- a/spec/string_foundation/convert_spec.rb
+++ b/spec/string_foundation/convert_spec.rb
@@ -158,7 +158,7 @@ describe '[ Convert Methods ]' do
     context 'when a string is an empty string,' do
       let(:string) { '' }
 
-      it { is_expected.to eq(nil) }
+      it { is_expected.to be_nil }
     end
   end
 


### PR DESCRIPTION
- Use a method "be_nil" instead of "eq(nil)" in test codes