### PR TITLE
Use double quotation mark instead of single

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 # GEM FILE
 # ==============================================================================
 # frozen_string_literal: true
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in string_foundation.gemspec.
 gemspec
@@ -13,8 +13,8 @@ gemspec
 group :development, :test do
 
   # Install bundler and rake.
-  gem 'bundler'
-  gem 'rake'
+  gem "bundler"
+  gem "rake"
 
 end
 
@@ -25,14 +25,14 @@ end
 group :test do
 
   # Use RSpec for unit test.
-  gem 'rspec'
+  gem "rspec"
   # Use a code coverage analysis tool for Ruby.
-  gem 'simplecov'
+  gem "simplecov"
   # Output the result of SimpleCov to a console.
-  gem 'simplecov-console'
+  gem "simplecov-console"
   # Use Codecov to get status badges.
-  gem 'codecov'
+  gem "codecov"
   # Generate random text.
-  gem 'random_token'
+  gem "random_token"
 
 end

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ gem install string_foundation
 If you are using Bundler, add this line to your application's Gemfile:
 
 ```ruby
-gem 'string_foundation'
+gem "string_foundation"
 ```
 
 And then run `bundle install` .
@@ -68,18 +68,18 @@ The following is a sample of what String Foundation provides.
 
 ```ruby
 # Check for convertible.
-'123'.to_i?  #=> true
-'x123'.to_i? #=> false
+"123".to_i?  #=> true
+"x123".to_i? #=> false
 
 # Remove leading zeros.
-'00000123'.without_leading_zeros #=> '123'
+"00000123".without_leading_zeros #=> "123"
 
 # Convert a value to the appropriate type.
-'false'.to_pretty #=> false
-'.5'.to_pretty    #=> 0.5
+"false".to_pretty #=> false
+".5".to_pretty    #=> 0.5
 
 # Convert to lowerCamelCase.
-'user_id'.to_lcamel #=> 'userId'
+"user_id".to_lcamel #=> "userId"
 ```
 
 
@@ -93,21 +93,21 @@ The `to_i?` method checks whether a string can be converted to an Integer
 is convertible, therefore it is not required for the argument to be an integral
 number. If you pass a floating point number as an argument to this method, it will
 return `true` because it can be converted using the `to_i` Ruby built-in method
-(for example, `'0.4'.to_i` returns `0` ).
+(for example, `"0.4".to_i` returns `0` ).
 
 ```ruby
-'123'.to_i? #=> true
-'0.3'.to_i? #=> true
-'.2'.to_i?  #=> true
+"123".to_i? #=> true
+"0.3".to_i? #=> true
+".2".to_i?  #=> true
 
-'abc'.to_i? #=> false
-'2x'.to_i?  #=> false
+"abc".to_i? #=> false
+"2x".to_i?  #=> false
 ```
 
 If an argument has leading zeros, they will be removed before checking.
 
 ```ruby
-'00000123'.to_i? #=> true
+"00000123".to_i? #=> true
 ```
 
 ### To Float
@@ -115,42 +115,42 @@ The `to_f?` method is to check convertibility to the Float class. This returns
 `true` only when an argument is convertible, therefore it is not required for the
 argument to be a floating point number. If you pass an integral number as an
 argument to this method, it will return `true` because it can be converted using
-the `to_f` Ruby built-in method (for example, `'2'.to_f` returns `2.0` ).
+the `to_f` Ruby built-in method (for example, `"2".to_f` returns `2.0` ).
 
 ```ruby
-'0.3'.to_f? #=> true
-'2'.to_f?   #=> true
-'.2'.to_f?  #=> true
+"0.3".to_f? #=> true
+"2".to_f?   #=> true
+".2".to_f?  #=> true
 
-'abc'.to_f?  #=> false
-'2.0x'.to_f? #=> false
+"abc".to_f?  #=> false
+"2.0x".to_f? #=> false
 ```
 
 
 ### To TrueClass / FalseClass
 The `to_bool?` method checks whether a string is convertible to TrueClass or
-FalseClass. This returns `true` or `false` only when the string is `'true'` or
-`'false'` .
+FalseClass. This returns `true` or `false` only when the string is `"true"` or
+`"false"` .
 
 ```ruby
-'true'.to_bool?  #=> true
-'false'.to_bool? #=> true
+"true".to_bool?  #=> true
+"false".to_bool? #=> true
 
-'abc'.to_bool?   #=> false
-'123'.to_bool?   #=> false
+"abc".to_bool?   #=> false
+"123".to_bool?   #=> false
 ```
 
 String Foundation also provides a check for a string's convertibility to a "Booly"
 (truthy or falsy). This returns `true` only when the string is a positive number,
-`'true'` , or an empty string. If not, it returns `false` .
+`"true"` , or an empty string. If not, it returns `false` .
 
 ```ruby
-'true'.to_booly? #=> true
-'123'.to_booly?  #=> true
-''.to_booly?     #=> true
-'-3'.to_booly?   #=> true
+"true".to_booly? #=> true
+"123".to_booly?  #=> true
+"".to_booly?     #=> true
+"-3".to_booly?   #=> true
 
-'abc'.to_booly?  #=> false
+"abc".to_booly?  #=> false
 ```
 
 
@@ -163,10 +163,10 @@ The `without_leading_zeros` method removes leading zeros (called "zero padding")
 This supports a floating point number and a string starting with a plus or minus sign.
 
 ```ruby
-'00001'.without_leading_zeros   #=> '1'
-'-0000.3'.without_leading_zeros #=> '-0.3'
+"00001".without_leading_zeros   #=> "1"
+"-0000.3".without_leading_zeros #=> "-0.3"
 
-%w(00001 00003 00008).map { |num| num.without_leading_zeros } #=> ['1', '3', '8']
+%w(00001 00003 00008).map { |num| num.without_leading_zeros } #=> ["1", "3", "8"]
 ```
 
 
@@ -178,53 +178,53 @@ or a proper class object. The Convert Methods make it easy to convert to these
 excluded classes.
 
 ### To TrueClass / FalseClass
-The `to_bool` method is for converting from a `'true'` or `'false'` string to `true`
+The `to_bool` method is for converting from a `"true"` or `"false"` string to `true`
 or `false` , otherwise it will raise a `TypeError` .
 
 ```ruby
-'true'.to_bool  #=> true
-'false'.to_bool #=> false
+"true".to_bool  #=> true
+"false".to_bool #=> false
 
-'1'.to_bool   #=> TypeError
-'0'.to_bool   #=> TypeError
-'-1'.to_bool  #=> TypeError
-'abc'.to_bool #=> TypeError
-''.to_bool    #=> TypeError
+"1".to_bool   #=> TypeError
+"0".to_bool   #=> TypeError
+"-1".to_bool  #=> TypeError
+"abc".to_bool #=> TypeError
+"".to_bool    #=> TypeError
 ```
 
 If you want to convert a Booly string, you can use the `to_booly` method. When a
-string is `'true'` or a positive number, this method will return `true` . Otherwise
+string is `"true"` or a positive number, this method will return `true` . Otherwise
 it will return `false` .
 
 ```ruby
-'true'.to_booly  #=> true
-'false'.to_booly #=> false
+"true".to_booly  #=> true
+"false".to_booly #=> false
 
-'1'.to_booly   #=> true
-'0'.to_booly   #=> false
-'-1'.to_booly  #=> false
-'abc'.to_booly #=> TypeError
-''.to_booly    #=> false
+"1".to_booly   #=> true
+"0".to_booly   #=> false
+"-1".to_booly  #=> false
+"abc".to_booly #=> TypeError
+"".to_booly    #=> false
 ```
 
 ### To Proper Class
 The `to_pretty` method is powerful. This method can convert to a proper class,
-for example, it will return a TrueClass `true` when a string is `'true'`, or returns
-an Integer `1` when a string is `'1'`.
+for example, it will return a TrueClass `true` when a string is `"true"`, or returns
+an Integer `1` when a string is `"1"`.
 Also this returns `nil` when a string is an empty string.
 
 ```ruby
-'1'.to_pretty      #=> 1
-'-3'.to_pretty     #=> -3
-'0004'.to_pretty   #=> 4
-'0.1'.to_pretty    #=> 0.1
-'-.5'.to_pretty    #=> -0.5
-'00.01'.to_pretty  #=> 0.01
+"1".to_pretty      #=> 1
+"-3".to_pretty     #=> -3
+"0004".to_pretty   #=> 4
+"0.1".to_pretty    #=> 0.1
+"-.5".to_pretty    #=> -0.5
+"00.01".to_pretty  #=> 0.01
 
-'true'.to_pretty  #=> true
-'false'.to_pretty #=> false
+"true".to_pretty  #=> true
+"false".to_pretty #=> false
 
-''.to_pretty #=> nil
+"".to_pretty #=> nil
 ```
 
 ### Newlines To Characters
@@ -232,8 +232,8 @@ The `nl_to` method converts a string with newlines to its specific characters.
 The `nl2` method is an alias for `nl_to` .
 
 ```ruby
-"Hi!\nWe are Brushdown.".nl_to(' / ') #=> 'Hi! / We are Brushdown.'
-"Hi!\nWe are Brushdown.".nl2(' / ')   #=> 'Hi! / We are Brushdown.'
+"Hi!\nWe are Brushdown.".nl_to(" / ") #=> "Hi! / We are Brushdown."
+"Hi!\nWe are Brushdown.".nl2(" / ")   #=> "Hi! / We are Brushdown."
 ```
 
 The `nl_to_br` method replaces the newlines in a string with HTML tag `<br>` for
@@ -241,14 +241,14 @@ break line.
 The `nl2br` method is an alias for `nl_to_br` .
 
 ```ruby
-"Hi!\nWe are Brushdown.".nl_to_br #=> 'Hi!<br>We are Brushdown.'
-"Hi!\nWe are Brushdown.".nl2br    #=> 'Hi!<br>We are Brushdown.'
+"Hi!\nWe are Brushdown.".nl_to_br #=> "Hi!<br>We are Brushdown."
+"Hi!\nWe are Brushdown.".nl2br    #=> "Hi!<br>We are Brushdown."
 ```
 
 
 ## The Like Methods
 The Like Methods provide to check whether a string is an integral number or a
-floating point number. These method ignore leading zeros, so the string `'000123'`
+floating point number. These method ignore leading zeros, so the string `"000123"`
 is regarded as an integral number. These method return `true` or `false` .
 
 The Like Methods check whether a string is an integral number or a floating point
@@ -259,26 +259,26 @@ as an integral number. These methods return `true` or `false` .
 The `like_i?` method checks whether a string is an integral number.
 
 ```ruby
-'123'.like_i? #=> true
-'00123'.like_i? #=> true
-'0.3'.like_i? #=> false
-'.2'.like_i?  #=> false
+"123".like_i? #=> true
+"00123".like_i? #=> true
+"0.3".like_i? #=> false
+".2".like_i?  #=> false
 
-'abc'.like_i? #=> false
-'2x'.like_i?  #=> false
+"abc".like_i? #=> false
+"2x".like_i?  #=> false
 ```
 
 ### Like Float
 The `like_f?` method checks whether a string is a floating point number.
 
 ```ruby
-'123'.like_f? #=> false
-'00123'.like_f? #=> false
-'0.3'.like_f? #=> true
-'.2'.like_f?  #=> true
+"123".like_f? #=> false
+"00123".like_f? #=> false
+"0.3".like_f? #=> true
+".2".like_f?  #=> true
 
-'abc'.like_f? #=> false
-'2x'.like_f?  #=> false
+"abc".like_f? #=> false
+"2x".like_f?  #=> false
 ```
 
 
@@ -300,8 +300,8 @@ The Case Methods convert to a case style, such as `lowerCamelCase` and
 | `to_udot`   | Upper Dot Case                | `We.Are.Brushdown` |
 
 ```ruby
-'user_id'.to_lcamel   #=> 'userId'
-'createdAt'.to_lsnake #=> 'created_at'
+"user_id".to_lcamel   #=> "userId"
+"createdAt".to_lsnake #=> "created_at"
 ```
 
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,8 @@
 # RAKE FILE
 # ==============================================================================
 # frozen_string_literal: true
-require 'bundler/gem_tasks'
-require 'rspec/core/rake_task'
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
 
 # ------------------------------------------------------------------------------
 # Configure Tasks

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ machine:
     CI: true
 dependencies:
   pre:
-    - 'case $CIRCLE_NODE_INDEX in 0) rvm use 2.1.0 --default ;; 1) rvm use 2.4.1 --default ;; esac'
+    - "case $CIRCLE_NODE_INDEX in 0) rvm use 2.1.0 --default ;; 1) rvm use 2.4.1 --default ;; esac"
 test:
   override:
     - ruby -v ; bundle exec rspec:

--- a/lib/string_foundation.rb
+++ b/lib/string_foundation.rb
@@ -3,4 +3,4 @@
 # ==============================================================================
 # frozen_string_literal: true
 # Require methods.
-Dir.glob(File.join(File.dirname(__FILE__), 'string_foundation','*.rb')).each { |f| require f }
+Dir.glob(File.join(File.dirname(__FILE__), "string_foundation", "*.rb")).each { |f| require f }

--- a/lib/string_foundation/case.rb
+++ b/lib/string_foundation/case.rb
@@ -30,8 +30,8 @@ class String
     self.split_camel.map do |cw|
       cw.split(/\.|_|-|\s/).map do |w|
         w.capitalize
-      end.join('_')
-    end.join('_')
+      end.join("_")
+    end.join("_")
   end
 
   # Convert to lower-kebab-case.
@@ -45,8 +45,8 @@ class String
     self.split_camel.map do |cw|
       cw.split(/\.|_|-|\s/).map do |w|
         w.capitalize
-      end.join('-')
-    end.join('-')
+      end.join("-")
+    end.join("-")
   end
 
   # Convert to lower space case.
@@ -60,8 +60,8 @@ class String
     self.split_camel.map do |cw|
       cw.split(/\.|_|-|\s/).map do |w|
         w.capitalize
-      end.join(' ')
-    end.join(' ')
+      end.join(" ")
+    end.join(" ")
   end
 
   # Convert to lower.dot.case.
@@ -75,8 +75,8 @@ class String
     self.split_camel.map do |cw|
       cw.split(/\.|_|-|\s/).map do |w|
         w.capitalize
-      end.join('.')
-    end.join('.')
+      end.join(".")
+    end.join(".")
   end
 
 

--- a/lib/string_foundation/convert.rb
+++ b/lib/string_foundation/convert.rb
@@ -2,9 +2,9 @@
 # LIB - STRING FOUNDATION - CONVERT
 # ==============================================================================
 # frozen_string_literal: true
-require_relative 'convertible'
-require_relative 'like'
-require_relative 'with'
+require_relative "convertible"
+require_relative "like"
+require_relative "with"
 class String
 
   # Convert to TrueClass or FalseClass.
@@ -13,7 +13,7 @@ class String
       raise TypeError.new("#{self} cannot be converted to TrueClass or FalseClass")
     end
 
-    (self == 'true')
+    (self == "true")
   end
 
   # Convert a booly string to TrueClass or FalseClass.
@@ -22,7 +22,7 @@ class String
       raise TypeError.new("#{self} cannot be converted to TrueClass or FalseClass")
     end
 
-    return true if self == 'true'  || (self.to_f? && self.to_f > 0)
+    return true if self == "true"  || (self.to_f? && self.to_f > 0)
     false
   end
 
@@ -37,13 +37,13 @@ class String
 
   # Convert from newline character to specific characters.
   def nl_to(char)
-    char = '' if char.nil?
+    char = "" if char.nil?
     self.gsub(/(\r\n|\n)/, char)
   end
 
   # Convert from newline character to a HTML tag "<br>".
   def nl_to_br
-    self.nl_to('<br>')
+    self.nl_to("<br>")
   end
 
   alias_method :nl2, :nl_to

--- a/lib/string_foundation/convertible.rb
+++ b/lib/string_foundation/convertible.rb
@@ -2,7 +2,7 @@
 # LIB - STRING FOUNDATION - CONVERTIBLE
 # ==============================================================================
 # frozen_string_literal: true
-require_relative 'with'
+require_relative "with"
 class String
 
   # Whether or not to be possible to covert String to Integer.

--- a/lib/string_foundation/like.rb
+++ b/lib/string_foundation/like.rb
@@ -2,7 +2,7 @@
 # LIB - STRING FOUNDATION - LIKE
 # ==============================================================================
 # frozen_string_literal: true
-require_relative 'convertible'
+require_relative "convertible"
 class String
 
   # Check whether a string is an integral number.
@@ -10,7 +10,7 @@ class String
     return false unless self.to_i?
 
     num = self.without_leading_zeros
-    (num.to_i == num.to_i) && !num.include?('.')
+    (num.to_i == num.to_i) && !num.include?(".")
   end
 
   # Check whether a string is a floating point number.
@@ -18,7 +18,7 @@ class String
     return false unless self.to_f?
 
     num = self.without_leading_zeros
-    (num.to_i != num.to_f) || num.include?('.')
+    (num.to_i != num.to_f) || num.include?(".")
   end
 
 end

--- a/lib/string_foundation/version.rb
+++ b/lib/string_foundation/version.rb
@@ -3,5 +3,5 @@
 # ==============================================================================
 # frozen_string_literal: true
 module StringFoundation
-  VERSION = '1.0.0'
+  VERSION = "1.0.0"
 end

--- a/lib/string_foundation/with.rb
+++ b/lib/string_foundation/with.rb
@@ -6,15 +6,15 @@ class String
 
   # Remove leading zeros.
   def without_leading_zeros
-    return self if self == '0'
+    return self if self == "0"
 
-    is_positive = self.start_with?('0')
-    is_negative = self.start_with?('-0')
+    is_positive = self.start_with?("0")
+    is_negative = self.start_with?("-0")
     if is_positive || is_negative
-      sig = self[0, self.length].gsub(/(^0+)|(^-0+)/, '')
+      sig = self[0, self.length].gsub(/(^0+)|(^-0+)/, "")
 
-      sig = '0' + sig if sig.start_with?('.') || sig.length == 0
-      sig = '-' + sig if is_negative && sig != '0'
+      sig = "0" + sig if sig.start_with?(".") || sig.length == 0
+      sig = "-" + sig if is_negative && sig != "0"
 
       sig
     else

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,10 +4,10 @@
 # frozen_string_literal: true
 # Configure Simple Cov to get coverage and Codecov.
 # !! These should be written at the beginning of this file to work. !!
-require 'simplecov'
-require 'simplecov-console'
-require 'codecov'
-if ENV['CI']
+require "simplecov"
+require "simplecov-console"
+require "codecov"
+if ENV["CI"]
   SimpleCov.formatter = SimpleCov::Formatter::Codecov
 else
   SimpleCov.formatters = [
@@ -18,12 +18,12 @@ end
 SimpleCov.start
 
 # Require core files.
-require 'bundler/setup'
-require 'string_foundation'
-require 'support/enhanced_matchers_extension'
+require "bundler/setup"
+require "string_foundation"
+require "support/enhanced_matchers_extension"
 
 # Require components.
-require 'random_token'
+require "random_token"
 
 # ------------------------------------------------------------------------------
 # RSpec Settings
@@ -32,7 +32,7 @@ RSpec.configure do |config|
   config.include EnhancedMatchersExtension
 
   # Enable flags like --only-failures and --next-failure .
-  config.example_status_persistence_file_path = '.rspec_status'
+  config.example_status_persistence_file_path = ".rspec_status"
 
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/string_foundation/case_spec.rb
+++ b/spec/string_foundation/case_spec.rb
@@ -2,98 +2,98 @@
 # SPEC - STRING FOUNDATION - CASE
 # ==============================================================================
 # frozen_string_literal: true
-describe '[ Case Methods ]' do
+describe "[ Case Methods ]" do
   # Define shared contexts.
   # ----------------------------------------------------------------------------
-  shared_context 'one word'         do let(:string) { 'string' }           end
-  shared_context 'lowerCamelCase'   do let(:string) { 'weAreBrushdown' }   end
-  shared_context 'UpperCamelCase'   do let(:string) { 'WeAreBrushdown' }   end
-  shared_context 'lower_snake_case' do let(:string) { 'we_are_brushdown' } end
-  shared_context 'Upper_Snake_Case' do let(:string) { 'We_Are_Brushdown' } end
-  shared_context 'lower-kebab-case' do let(:string) { 'we-are-brushdown' } end
-  shared_context 'Upper-Kebab-Case' do let(:string) { 'We-Are-Brushdown' } end
-  shared_context 'lower space case' do let(:string) { 'we are brushdown' } end
-  shared_context 'Upper Space Case' do let(:string) { 'We Are Brushdown' } end
-  shared_context 'lower.dot.case'   do let(:string) { 'we.are.brushdown' } end
-  shared_context 'Upper.Dot.Case'   do let(:string) { 'We.Are.Brushdown' } end
+  shared_context "one word"         do let(:string) { "string" }           end
+  shared_context "lowerCamelCase"   do let(:string) { "weAreBrushdown" }   end
+  shared_context "UpperCamelCase"   do let(:string) { "WeAreBrushdown" }   end
+  shared_context "lower_snake_case" do let(:string) { "we_are_brushdown" } end
+  shared_context "Upper_Snake_Case" do let(:string) { "We_Are_Brushdown" } end
+  shared_context "lower-kebab-case" do let(:string) { "we-are-brushdown" } end
+  shared_context "Upper-Kebab-Case" do let(:string) { "We-Are-Brushdown" } end
+  shared_context "lower space case" do let(:string) { "we are brushdown" } end
+  shared_context "Upper Space Case" do let(:string) { "We Are Brushdown" } end
+  shared_context "lower.dot.case"   do let(:string) { "we.are.brushdown" } end
+  shared_context "Upper.Dot.Case"   do let(:string) { "We.Are.Brushdown" } end
   # ----------------------------------------------------------------------------
 
   # ----------------------------------------------------------------------------
   # Convert to lowerCamelCase
   # ----------------------------------------------------------------------------
-  describe 'CONVERT TO lowerCamelCase ::' do
+  describe "CONVERT TO lowerCamelCase ::" do
     subject { string.to_lcamel }
 
     # Define shared examples.
     # --------------------------------------------------------------------------
-    shared_examples 'be converted to lowerCamelCase' do
-      it { is_expected.to eq('weAreBrushdown') }
+    shared_examples "be converted to lowerCamelCase" do
+      it { is_expected.to eq("weAreBrushdown") }
     end
     # --------------------------------------------------------------------------
 
-    context 'When a string has one word,' do
-      include_context 'one word'
+    context "When a string has one word," do
+      include_context "one word"
 
-      it { is_expected.to eq('string') }
+      it { is_expected.to eq("string") }
     end
 
-    context 'When a string lowerCamelCase,' do
-      include_context 'lowerCamelCase'
+    context "When a string lowerCamelCase," do
+      include_context "lowerCamelCase"
 
-      it_behaves_like 'be converted to lowerCamelCase'
+      it_behaves_like "be converted to lowerCamelCase"
     end
 
-    context 'When a string UpperCamelCase,' do
-      include_context 'UpperCamelCase'
+    context "When a string UpperCamelCase," do
+      include_context "UpperCamelCase"
 
-      it_behaves_like 'be converted to lowerCamelCase'
+      it_behaves_like "be converted to lowerCamelCase"
     end
 
-    context 'When a string lower_snake_case,' do
-      include_context 'lower_snake_case'
+    context "When a string lower_snake_case," do
+      include_context "lower_snake_case"
 
-      it_behaves_like 'be converted to lowerCamelCase'
+      it_behaves_like "be converted to lowerCamelCase"
     end
 
-    context 'When a string Upper_Snake_Case,' do
-      include_context 'Upper_Snake_Case'
+    context "When a string Upper_Snake_Case," do
+      include_context "Upper_Snake_Case"
 
-      it_behaves_like 'be converted to lowerCamelCase'
+      it_behaves_like "be converted to lowerCamelCase"
     end
 
-    context 'When a string lower-kebab-case,' do
-      include_context 'lower-kebab-case'
+    context "When a string lower-kebab-case," do
+      include_context "lower-kebab-case"
 
-      it_behaves_like 'be converted to lowerCamelCase'
+      it_behaves_like "be converted to lowerCamelCase"
     end
 
-    context 'When a string Upper-Kebab-Case,' do
-      include_context 'Upper-Kebab-Case'
+    context "When a string Upper-Kebab-Case," do
+      include_context "Upper-Kebab-Case"
 
-      it_behaves_like 'be converted to lowerCamelCase'
+      it_behaves_like "be converted to lowerCamelCase"
     end
 
-    context 'When a string lower space case,' do
-      include_context 'lower space case'
+    context "When a string lower space case," do
+      include_context "lower space case"
 
-      it_behaves_like 'be converted to lowerCamelCase'
+      it_behaves_like "be converted to lowerCamelCase"
     end
 
-    context 'When a string Upper Space Case,' do
-      include_context 'Upper Space Case'
+    context "When a string Upper Space Case," do
+      include_context "Upper Space Case"
 
-      it_behaves_like 'be converted to lowerCamelCase'
+      it_behaves_like "be converted to lowerCamelCase"
     end
-    context 'When a string lower.dot.case,' do
-      include_context 'lower.dot.case'
+    context "When a string lower.dot.case," do
+      include_context "lower.dot.case"
 
-      it_behaves_like 'be converted to lowerCamelCase'
+      it_behaves_like "be converted to lowerCamelCase"
     end
 
-    context 'When a string Upper.Dot.Case,' do
-      include_context 'Upper.Dot.Case'
+    context "When a string Upper.Dot.Case," do
+      include_context "Upper.Dot.Case"
 
-      it_behaves_like 'be converted to lowerCamelCase'
+      it_behaves_like "be converted to lowerCamelCase"
     end
   end
 
@@ -101,79 +101,79 @@ describe '[ Case Methods ]' do
   # ----------------------------------------------------------------------------
   # Convert to UpperCamelCase
   # ----------------------------------------------------------------------------
-  describe 'CONVERT TO UpperCamelCase ::' do
+  describe "CONVERT TO UpperCamelCase ::" do
     subject { string.to_ucamel }
 
     # Define shared examples.
     # --------------------------------------------------------------------------
-    shared_examples 'be converted to UpperCamelCase' do
-      it { is_expected.to eq('WeAreBrushdown') }
+    shared_examples "be converted to UpperCamelCase" do
+      it { is_expected.to eq("WeAreBrushdown") }
     end
     # --------------------------------------------------------------------------
 
-    context 'When a string has one word,' do
-      include_context 'one word'
+    context "When a string has one word," do
+      include_context "one word"
 
-      it { is_expected.to eq('String') }
+      it { is_expected.to eq("String") }
     end
 
-    context 'When a string lowerCamelCase,' do
-      include_context 'lowerCamelCase'
+    context "When a string lowerCamelCase," do
+      include_context "lowerCamelCase"
 
-      it_behaves_like 'be converted to UpperCamelCase'
+      it_behaves_like "be converted to UpperCamelCase"
     end
 
-    context 'When a string UpperCamelCase,' do
-      include_context 'UpperCamelCase'
+    context "When a string UpperCamelCase," do
+      include_context "UpperCamelCase"
 
-      it_behaves_like 'be converted to UpperCamelCase'
+      it_behaves_like "be converted to UpperCamelCase"
     end
 
-    context 'When a string lower_snake_case,' do
-      include_context 'lower_snake_case'
+    context "When a string lower_snake_case," do
+      include_context "lower_snake_case"
 
-      it_behaves_like 'be converted to UpperCamelCase'
+      it_behaves_like "be converted to UpperCamelCase"
     end
 
-    context 'When a string Upper_Snake_Case,' do
-      include_context 'Upper_Snake_Case'
+    context "When a string Upper_Snake_Case," do
+      include_context "Upper_Snake_Case"
 
-      it_behaves_like 'be converted to UpperCamelCase'
+      it_behaves_like "be converted to UpperCamelCase"
     end
 
-    context 'When a string lower-kebab-case,' do
-      include_context 'lower-kebab-case'
+    context "When a string lower-kebab-case," do
+      include_context "lower-kebab-case"
 
-      it_behaves_like 'be converted to UpperCamelCase'
+      it_behaves_like "be converted to UpperCamelCase"
     end
 
-    context 'When a string Upper-Kebab-Case,' do
-      include_context 'Upper-Kebab-Case'
+    context "When a string Upper-Kebab-Case," do
+      include_context "Upper-Kebab-Case"
 
-      it_behaves_like 'be converted to UpperCamelCase'
+      it_behaves_like "be converted to UpperCamelCase"
     end
 
-    context 'When a string lower space case,' do
-      include_context 'lower space case'
+    context "When a string lower space case," do
+      include_context "lower space case"
 
-      it_behaves_like 'be converted to UpperCamelCase'
+      it_behaves_like "be converted to UpperCamelCase"
     end
 
-    context 'When a string Upper Space Case,' do
-      include_context 'Upper Space Case'
+    context "When a string Upper Space Case," do
+      include_context "Upper Space Case"
 
-      it_behaves_like 'be converted to UpperCamelCase'
+      it_behaves_like "be converted to UpperCamelCase"
     end
-    context 'When a string lower.dot.case,' do
-      include_context 'lower.dot.case'
+    context "When a string lower.dot.case," do
+      include_context "lower.dot.case"
 
-      it_behaves_like 'be converted to UpperCamelCase'
+      it_behaves_like "be converted to UpperCamelCase"
     end
 
-    context 'When a string Upper.Dot.Case,' do
-      include_context 'Upper.Dot.Case'
+    context "When a string Upper.Dot.Case," do
+      include_context "Upper.Dot.Case"
 
-      it_behaves_like 'be converted to UpperCamelCase'
+      it_behaves_like "be converted to UpperCamelCase"
     end
   end
 
@@ -181,79 +181,79 @@ describe '[ Case Methods ]' do
   # ----------------------------------------------------------------------------
   # Convert to lower_snake_case
   # ----------------------------------------------------------------------------
-  describe 'CONVERT TO lower_snake_case ::' do
+  describe "CONVERT TO lower_snake_case ::" do
     subject { string.to_lsnake }
 
     # Define shared examples.
     # --------------------------------------------------------------------------
-    shared_examples 'be converted to lower_snake_case' do
-      it { is_expected.to eq('we_are_brushdown') }
+    shared_examples "be converted to lower_snake_case" do
+      it { is_expected.to eq("we_are_brushdown") }
     end
     # --------------------------------------------------------------------------
 
-    context 'When a string has one word,' do
-      include_context 'one word'
+    context "When a string has one word," do
+      include_context "one word"
 
-      it { is_expected.to eq('string') }
+      it { is_expected.to eq("string") }
     end
 
-    context 'When a string lowerCamelCase,' do
-      include_context 'lowerCamelCase'
+    context "When a string lowerCamelCase," do
+      include_context "lowerCamelCase"
 
-      it_behaves_like 'be converted to lower_snake_case'
+      it_behaves_like "be converted to lower_snake_case"
     end
 
-    context 'When a string UpperCamelCase,' do
-      include_context 'UpperCamelCase'
+    context "When a string UpperCamelCase," do
+      include_context "UpperCamelCase"
 
-      it_behaves_like 'be converted to lower_snake_case'
+      it_behaves_like "be converted to lower_snake_case"
     end
 
-    context 'When a string lower_snake_case,' do
-      include_context 'lower_snake_case'
+    context "When a string lower_snake_case," do
+      include_context "lower_snake_case"
 
-      it_behaves_like 'be converted to lower_snake_case'
+      it_behaves_like "be converted to lower_snake_case"
     end
 
-    context 'When a string Upper_Snake_Case,' do
-      include_context 'Upper_Snake_Case'
+    context "When a string Upper_Snake_Case," do
+      include_context "Upper_Snake_Case"
 
-      it_behaves_like 'be converted to lower_snake_case'
+      it_behaves_like "be converted to lower_snake_case"
     end
 
-    context 'When a string lower-kebab-case,' do
-      include_context 'lower-kebab-case'
+    context "When a string lower-kebab-case," do
+      include_context "lower-kebab-case"
 
-      it_behaves_like 'be converted to lower_snake_case'
+      it_behaves_like "be converted to lower_snake_case"
     end
 
-    context 'When a string Upper-Kebab-Case,' do
-      include_context 'Upper-Kebab-Case'
+    context "When a string Upper-Kebab-Case," do
+      include_context "Upper-Kebab-Case"
 
-      it_behaves_like 'be converted to lower_snake_case'
+      it_behaves_like "be converted to lower_snake_case"
     end
 
-    context 'When a string lower space case,' do
-      include_context 'lower space case'
+    context "When a string lower space case," do
+      include_context "lower space case"
 
-      it_behaves_like 'be converted to lower_snake_case'
+      it_behaves_like "be converted to lower_snake_case"
     end
 
-    context 'When a string Upper Space Case,' do
-      include_context 'Upper Space Case'
+    context "When a string Upper Space Case," do
+      include_context "Upper Space Case"
 
-      it_behaves_like 'be converted to lower_snake_case'
+      it_behaves_like "be converted to lower_snake_case"
     end
-    context 'When a string lower.dot.case,' do
-      include_context 'lower.dot.case'
+    context "When a string lower.dot.case," do
+      include_context "lower.dot.case"
 
-      it_behaves_like 'be converted to lower_snake_case'
+      it_behaves_like "be converted to lower_snake_case"
     end
 
-    context 'When a string Upper.Dot.Case,' do
-      include_context 'Upper.Dot.Case'
+    context "When a string Upper.Dot.Case," do
+      include_context "Upper.Dot.Case"
 
-      it_behaves_like 'be converted to lower_snake_case'
+      it_behaves_like "be converted to lower_snake_case"
     end
   end
 
@@ -261,79 +261,79 @@ describe '[ Case Methods ]' do
   # ----------------------------------------------------------------------------
   # Convert to Upper_Snake_Case
   # ----------------------------------------------------------------------------
-  describe 'CONVERT TO Upper_Snake_Case ::' do
+  describe "CONVERT TO Upper_Snake_Case ::" do
     subject { string.to_usnake }
 
     # Define shared examples.
     # --------------------------------------------------------------------------
-    shared_examples 'be converted to Upper_Snake_Case' do
-      it { is_expected.to eq('We_Are_Brushdown') }
+    shared_examples "be converted to Upper_Snake_Case" do
+      it { is_expected.to eq("We_Are_Brushdown") }
     end
     # --------------------------------------------------------------------------
 
-    context 'When a string has one word,' do
-      include_context 'one word'
+    context "When a string has one word," do
+      include_context "one word"
 
-      it { is_expected.to eq('String') }
+      it { is_expected.to eq("String") }
     end
 
-    context 'When a string lowerCamelCase,' do
-      include_context 'lowerCamelCase'
+    context "When a string lowerCamelCase," do
+      include_context "lowerCamelCase"
 
-      it_behaves_like 'be converted to Upper_Snake_Case'
+      it_behaves_like "be converted to Upper_Snake_Case"
     end
 
-    context 'When a string UpperCamelCase,' do
-      include_context 'UpperCamelCase'
+    context "When a string UpperCamelCase," do
+      include_context "UpperCamelCase"
 
-      it_behaves_like 'be converted to Upper_Snake_Case'
+      it_behaves_like "be converted to Upper_Snake_Case"
     end
 
-    context 'When a string lower_snake_case,' do
-      include_context 'lower_snake_case'
+    context "When a string lower_snake_case," do
+      include_context "lower_snake_case"
 
-      it_behaves_like 'be converted to Upper_Snake_Case'
+      it_behaves_like "be converted to Upper_Snake_Case"
     end
 
-    context 'When a string Upper_Snake_Case,' do
-      include_context 'Upper_Snake_Case'
+    context "When a string Upper_Snake_Case," do
+      include_context "Upper_Snake_Case"
 
-      it_behaves_like 'be converted to Upper_Snake_Case'
+      it_behaves_like "be converted to Upper_Snake_Case"
     end
 
-    context 'When a string lower-kebab-case,' do
-      include_context 'lower-kebab-case'
+    context "When a string lower-kebab-case," do
+      include_context "lower-kebab-case"
 
-      it_behaves_like 'be converted to Upper_Snake_Case'
+      it_behaves_like "be converted to Upper_Snake_Case"
     end
 
-    context 'When a string Upper-Kebab-Case,' do
-      include_context 'Upper-Kebab-Case'
+    context "When a string Upper-Kebab-Case," do
+      include_context "Upper-Kebab-Case"
 
-      it_behaves_like 'be converted to Upper_Snake_Case'
+      it_behaves_like "be converted to Upper_Snake_Case"
     end
 
-    context 'When a string lower space case,' do
-      include_context 'lower space case'
+    context "When a string lower space case," do
+      include_context "lower space case"
 
-      it_behaves_like 'be converted to Upper_Snake_Case'
+      it_behaves_like "be converted to Upper_Snake_Case"
     end
 
-    context 'When a string Upper Space Case,' do
-      include_context 'Upper Space Case'
+    context "When a string Upper Space Case," do
+      include_context "Upper Space Case"
 
-      it_behaves_like 'be converted to Upper_Snake_Case'
+      it_behaves_like "be converted to Upper_Snake_Case"
     end
-    context 'When a string lower.dot.case,' do
-      include_context 'lower.dot.case'
+    context "When a string lower.dot.case," do
+      include_context "lower.dot.case"
 
-      it_behaves_like 'be converted to Upper_Snake_Case'
+      it_behaves_like "be converted to Upper_Snake_Case"
     end
 
-    context 'When a string Upper.Dot.Case,' do
-      include_context 'Upper.Dot.Case'
+    context "When a string Upper.Dot.Case," do
+      include_context "Upper.Dot.Case"
 
-      it_behaves_like 'be converted to Upper_Snake_Case'
+      it_behaves_like "be converted to Upper_Snake_Case"
     end
   end
 
@@ -341,79 +341,79 @@ describe '[ Case Methods ]' do
   # ----------------------------------------------------------------------------
   # Convert to lower-kebab-case
   # ----------------------------------------------------------------------------
-  describe 'CONVERT TO lower-kebab-case ::' do
+  describe "CONVERT TO lower-kebab-case ::" do
     subject { string.to_lkebab }
 
     # Define shared examples.
     # --------------------------------------------------------------------------
-    shared_examples 'be converted to lower-kebab-case' do
-      it { is_expected.to eq('we-are-brushdown') }
+    shared_examples "be converted to lower-kebab-case" do
+      it { is_expected.to eq("we-are-brushdown") }
     end
     # --------------------------------------------------------------------------
 
-    context 'When a string has one word,' do
-      include_context 'one word'
+    context "When a string has one word," do
+      include_context "one word"
 
-      it { is_expected.to eq('string') }
+      it { is_expected.to eq("string") }
     end
 
-    context 'When a string lowerCamelCase,' do
-      include_context 'lowerCamelCase'
+    context "When a string lowerCamelCase," do
+      include_context "lowerCamelCase"
 
-      it_behaves_like 'be converted to lower-kebab-case'
+      it_behaves_like "be converted to lower-kebab-case"
     end
 
-    context 'When a string UpperCamelCase,' do
-      include_context 'UpperCamelCase'
+    context "When a string UpperCamelCase," do
+      include_context "UpperCamelCase"
 
-      it_behaves_like 'be converted to lower-kebab-case'
+      it_behaves_like "be converted to lower-kebab-case"
     end
 
-    context 'When a string lower_snake_case,' do
-      include_context 'lower_snake_case'
+    context "When a string lower_snake_case," do
+      include_context "lower_snake_case"
 
-      it_behaves_like 'be converted to lower-kebab-case'
+      it_behaves_like "be converted to lower-kebab-case"
     end
 
-    context 'When a string Upper_Snake_Case,' do
-      include_context 'Upper_Snake_Case'
+    context "When a string Upper_Snake_Case," do
+      include_context "Upper_Snake_Case"
 
-      it_behaves_like 'be converted to lower-kebab-case'
+      it_behaves_like "be converted to lower-kebab-case"
     end
 
-    context 'When a string lower-kebab-case,' do
-      include_context 'lower-kebab-case'
+    context "When a string lower-kebab-case," do
+      include_context "lower-kebab-case"
 
-      it_behaves_like 'be converted to lower-kebab-case'
+      it_behaves_like "be converted to lower-kebab-case"
     end
 
-    context 'When a string Upper-Kebab-Case,' do
-      include_context 'Upper-Kebab-Case'
+    context "When a string Upper-Kebab-Case," do
+      include_context "Upper-Kebab-Case"
 
-      it_behaves_like 'be converted to lower-kebab-case'
+      it_behaves_like "be converted to lower-kebab-case"
     end
 
-    context 'When a string lower space case,' do
-      include_context 'lower space case'
+    context "When a string lower space case," do
+      include_context "lower space case"
 
-      it_behaves_like 'be converted to lower-kebab-case'
+      it_behaves_like "be converted to lower-kebab-case"
     end
 
-    context 'When a string Upper Space Case,' do
-      include_context 'Upper Space Case'
+    context "When a string Upper Space Case," do
+      include_context "Upper Space Case"
 
-      it_behaves_like 'be converted to lower-kebab-case'
+      it_behaves_like "be converted to lower-kebab-case"
     end
-    context 'When a string lower.dot.case,' do
-      include_context 'lower.dot.case'
+    context "When a string lower.dot.case," do
+      include_context "lower.dot.case"
 
-      it_behaves_like 'be converted to lower-kebab-case'
+      it_behaves_like "be converted to lower-kebab-case"
     end
 
-    context 'When a string Upper.Dot.Case,' do
-      include_context 'Upper.Dot.Case'
+    context "When a string Upper.Dot.Case," do
+      include_context "Upper.Dot.Case"
 
-      it_behaves_like 'be converted to lower-kebab-case'
+      it_behaves_like "be converted to lower-kebab-case"
     end
   end
 
@@ -421,79 +421,79 @@ describe '[ Case Methods ]' do
   # ----------------------------------------------------------------------------
   # Convert to Upper-Kebab-Case
   # ----------------------------------------------------------------------------
-  describe 'CONVERT TO Upper-Kebab-Case ::' do
+  describe "CONVERT TO Upper-Kebab-Case ::" do
     subject { string.to_ukebab }
 
     # Define shared examples.
     # --------------------------------------------------------------------------
-    shared_examples 'be converted to Upper-Kebab-Case' do
-      it { is_expected.to eq('We-Are-Brushdown') }
+    shared_examples "be converted to Upper-Kebab-Case" do
+      it { is_expected.to eq("We-Are-Brushdown") }
     end
     # --------------------------------------------------------------------------
 
-    context 'When a string has one word,' do
-      include_context 'one word'
+    context "When a string has one word," do
+      include_context "one word"
 
-      it { is_expected.to eq('String') }
+      it { is_expected.to eq("String") }
     end
 
-    context 'When a string lowerCamelCase,' do
-      include_context 'lowerCamelCase'
+    context "When a string lowerCamelCase," do
+      include_context "lowerCamelCase"
 
-      it_behaves_like 'be converted to Upper-Kebab-Case'
+      it_behaves_like "be converted to Upper-Kebab-Case"
     end
 
-    context 'When a string UpperCamelCase,' do
-      include_context 'UpperCamelCase'
+    context "When a string UpperCamelCase," do
+      include_context "UpperCamelCase"
 
-      it_behaves_like 'be converted to Upper-Kebab-Case'
+      it_behaves_like "be converted to Upper-Kebab-Case"
     end
 
-    context 'When a string lower_snake_case,' do
-      include_context 'lower_snake_case'
+    context "When a string lower_snake_case," do
+      include_context "lower_snake_case"
 
-      it_behaves_like 'be converted to Upper-Kebab-Case'
+      it_behaves_like "be converted to Upper-Kebab-Case"
     end
 
-    context 'When a string Upper_Snake_Case,' do
-      include_context 'Upper_Snake_Case'
+    context "When a string Upper_Snake_Case," do
+      include_context "Upper_Snake_Case"
 
-      it_behaves_like 'be converted to Upper-Kebab-Case'
+      it_behaves_like "be converted to Upper-Kebab-Case"
     end
 
-    context 'When a string lower-kebab-case,' do
-      include_context 'lower-kebab-case'
+    context "When a string lower-kebab-case," do
+      include_context "lower-kebab-case"
 
-      it_behaves_like 'be converted to Upper-Kebab-Case'
+      it_behaves_like "be converted to Upper-Kebab-Case"
     end
 
-    context 'When a string Upper-Kebab-Case,' do
-      include_context 'Upper-Kebab-Case'
+    context "When a string Upper-Kebab-Case," do
+      include_context "Upper-Kebab-Case"
 
-      it_behaves_like 'be converted to Upper-Kebab-Case'
+      it_behaves_like "be converted to Upper-Kebab-Case"
     end
 
-    context 'When a string lower space case,' do
-      include_context 'lower space case'
+    context "When a string lower space case," do
+      include_context "lower space case"
 
-      it_behaves_like 'be converted to Upper-Kebab-Case'
+      it_behaves_like "be converted to Upper-Kebab-Case"
     end
 
-    context 'When a string Upper Space Case,' do
-      include_context 'Upper Space Case'
+    context "When a string Upper Space Case," do
+      include_context "Upper Space Case"
 
-      it_behaves_like 'be converted to Upper-Kebab-Case'
+      it_behaves_like "be converted to Upper-Kebab-Case"
     end
-    context 'When a string lower.dot.case,' do
-      include_context 'lower.dot.case'
+    context "When a string lower.dot.case," do
+      include_context "lower.dot.case"
 
-      it_behaves_like 'be converted to Upper-Kebab-Case'
+      it_behaves_like "be converted to Upper-Kebab-Case"
     end
 
-    context 'When a string Upper.Dot.Case,' do
-      include_context 'Upper.Dot.Case'
+    context "When a string Upper.Dot.Case," do
+      include_context "Upper.Dot.Case"
 
-      it_behaves_like 'be converted to Upper-Kebab-Case'
+      it_behaves_like "be converted to Upper-Kebab-Case"
     end
   end
 
@@ -501,79 +501,79 @@ describe '[ Case Methods ]' do
   # ----------------------------------------------------------------------------
   # Convert to lower space case
   # ----------------------------------------------------------------------------
-  describe 'CONVERT TO lower space case ::' do
+  describe "CONVERT TO lower space case ::" do
     subject { string.to_lspace }
 
     # Define shared examples.
     # --------------------------------------------------------------------------
-    shared_examples 'be converted to lower space case' do
-      it { is_expected.to eq('we are brushdown') }
+    shared_examples "be converted to lower space case" do
+      it { is_expected.to eq("we are brushdown") }
     end
     # --------------------------------------------------------------------------
 
-    context 'When a string has one word,' do
-      include_context 'one word'
+    context "When a string has one word," do
+      include_context "one word"
 
-      it { is_expected.to eq('string') }
+      it { is_expected.to eq("string") }
     end
 
-    context 'When a string lowerCamelCase,' do
-      include_context 'lowerCamelCase'
+    context "When a string lowerCamelCase," do
+      include_context "lowerCamelCase"
 
-      it_behaves_like 'be converted to lower space case'
+      it_behaves_like "be converted to lower space case"
     end
 
-    context 'When a string UpperCamelCase,' do
-      include_context 'UpperCamelCase'
+    context "When a string UpperCamelCase," do
+      include_context "UpperCamelCase"
 
-      it_behaves_like 'be converted to lower space case'
+      it_behaves_like "be converted to lower space case"
     end
 
-    context 'When a string lower_snake_case,' do
-      include_context 'lower_snake_case'
+    context "When a string lower_snake_case," do
+      include_context "lower_snake_case"
 
-      it_behaves_like 'be converted to lower space case'
+      it_behaves_like "be converted to lower space case"
     end
 
-    context 'When a string Upper_Snake_Case,' do
-      include_context 'Upper_Snake_Case'
+    context "When a string Upper_Snake_Case," do
+      include_context "Upper_Snake_Case"
 
-      it_behaves_like 'be converted to lower space case'
+      it_behaves_like "be converted to lower space case"
     end
 
-    context 'When a string lower-kebab-case,' do
-      include_context 'lower-kebab-case'
+    context "When a string lower-kebab-case," do
+      include_context "lower-kebab-case"
 
-      it_behaves_like 'be converted to lower space case'
+      it_behaves_like "be converted to lower space case"
     end
 
-    context 'When a string Upper-Kebab-Case,' do
-      include_context 'Upper-Kebab-Case'
+    context "When a string Upper-Kebab-Case," do
+      include_context "Upper-Kebab-Case"
 
-      it_behaves_like 'be converted to lower space case'
+      it_behaves_like "be converted to lower space case"
     end
 
-    context 'When a string lower space case,' do
-      include_context 'lower space case'
+    context "When a string lower space case," do
+      include_context "lower space case"
 
-      it_behaves_like 'be converted to lower space case'
+      it_behaves_like "be converted to lower space case"
     end
 
-    context 'When a string Upper Space Case,' do
-      include_context 'Upper Space Case'
+    context "When a string Upper Space Case," do
+      include_context "Upper Space Case"
 
-      it_behaves_like 'be converted to lower space case'
+      it_behaves_like "be converted to lower space case"
     end
-    context 'When a string lower.dot.case,' do
-      include_context 'lower.dot.case'
+    context "When a string lower.dot.case," do
+      include_context "lower.dot.case"
 
-      it_behaves_like 'be converted to lower space case'
+      it_behaves_like "be converted to lower space case"
     end
 
-    context 'When a string Upper.Dot.Case,' do
-      include_context 'Upper.Dot.Case'
+    context "When a string Upper.Dot.Case," do
+      include_context "Upper.Dot.Case"
 
-      it_behaves_like 'be converted to lower space case'
+      it_behaves_like "be converted to lower space case"
     end
   end
 
@@ -581,79 +581,79 @@ describe '[ Case Methods ]' do
   # ----------------------------------------------------------------------------
   # Convert to Upper Space Case
   # ----------------------------------------------------------------------------
-  describe 'CONVERT TO Upper Space Case ::' do
+  describe "CONVERT TO Upper Space Case ::" do
     subject { string.to_uspace }
 
     # Define shared examples.
     # --------------------------------------------------------------------------
-    shared_examples 'be converted to Upper Space Case' do
-      it { is_expected.to eq('We Are Brushdown') }
+    shared_examples "be converted to Upper Space Case" do
+      it { is_expected.to eq("We Are Brushdown") }
     end
     # --------------------------------------------------------------------------
 
-    context 'When a string has one word,' do
-      include_context 'one word'
+    context "When a string has one word," do
+      include_context "one word"
 
-      it { is_expected.to eq('String') }
+      it { is_expected.to eq("String") }
     end
 
-    context 'When a string lowerCamelCase,' do
-      include_context 'lowerCamelCase'
+    context "When a string lowerCamelCase," do
+      include_context "lowerCamelCase"
 
-      it_behaves_like 'be converted to Upper Space Case'
+      it_behaves_like "be converted to Upper Space Case"
     end
 
-    context 'When a string UpperCamelCase,' do
-      include_context 'UpperCamelCase'
+    context "When a string UpperCamelCase," do
+      include_context "UpperCamelCase"
 
-      it_behaves_like 'be converted to Upper Space Case'
+      it_behaves_like "be converted to Upper Space Case"
     end
 
-    context 'When a string lower_snake_case,' do
-      include_context 'lower_snake_case'
+    context "When a string lower_snake_case," do
+      include_context "lower_snake_case"
 
-      it_behaves_like 'be converted to Upper Space Case'
+      it_behaves_like "be converted to Upper Space Case"
     end
 
-    context 'When a string Upper_Snake_Case,' do
-      include_context 'Upper_Snake_Case'
+    context "When a string Upper_Snake_Case," do
+      include_context "Upper_Snake_Case"
 
-      it_behaves_like 'be converted to Upper Space Case'
+      it_behaves_like "be converted to Upper Space Case"
     end
 
-    context 'When a string lower-kebab-case,' do
-      include_context 'lower-kebab-case'
+    context "When a string lower-kebab-case," do
+      include_context "lower-kebab-case"
 
-      it_behaves_like 'be converted to Upper Space Case'
+      it_behaves_like "be converted to Upper Space Case"
     end
 
-    context 'When a string Upper-Kebab-Case,' do
-      include_context 'Upper-Kebab-Case'
+    context "When a string Upper-Kebab-Case," do
+      include_context "Upper-Kebab-Case"
 
-      it_behaves_like 'be converted to Upper Space Case'
+      it_behaves_like "be converted to Upper Space Case"
     end
 
-    context 'When a string lower space case,' do
-      include_context 'lower space case'
+    context "When a string lower space case," do
+      include_context "lower space case"
 
-      it_behaves_like 'be converted to Upper Space Case'
+      it_behaves_like "be converted to Upper Space Case"
     end
 
-    context 'When a string Upper Space Case,' do
-      include_context 'Upper Space Case'
+    context "When a string Upper Space Case," do
+      include_context "Upper Space Case"
 
-      it_behaves_like 'be converted to Upper Space Case'
+      it_behaves_like "be converted to Upper Space Case"
     end
-    context 'When a string lower.dot.case,' do
-      include_context 'lower.dot.case'
+    context "When a string lower.dot.case," do
+      include_context "lower.dot.case"
 
-      it_behaves_like 'be converted to Upper Space Case'
+      it_behaves_like "be converted to Upper Space Case"
     end
 
-    context 'When a string Upper.Dot.Case,' do
-      include_context 'Upper.Dot.Case'
+    context "When a string Upper.Dot.Case," do
+      include_context "Upper.Dot.Case"
 
-      it_behaves_like 'be converted to Upper Space Case'
+      it_behaves_like "be converted to Upper Space Case"
     end
   end
 
@@ -661,79 +661,79 @@ describe '[ Case Methods ]' do
   # ----------------------------------------------------------------------------
   # Convert to lower.dot.case
   # ----------------------------------------------------------------------------
-  describe 'CONVERT TO lower.dot.case ::' do
+  describe "CONVERT TO lower.dot.case ::" do
     subject { string.to_ldot }
 
     # Define shared examples.
     # --------------------------------------------------------------------------
-    shared_examples 'be converted to lower.dot.case' do
-      it { is_expected.to eq('we.are.brushdown') }
+    shared_examples "be converted to lower.dot.case" do
+      it { is_expected.to eq("we.are.brushdown") }
     end
     # --------------------------------------------------------------------------
 
-    context 'When a string has one word,' do
-      include_context 'one word'
+    context "When a string has one word," do
+      include_context "one word"
 
-      it { is_expected.to eq('string') }
+      it { is_expected.to eq("string") }
     end
 
-    context 'When a string lowerCamelCase,' do
-      include_context 'lowerCamelCase'
+    context "When a string lowerCamelCase," do
+      include_context "lowerCamelCase"
 
-      it_behaves_like 'be converted to lower.dot.case'
+      it_behaves_like "be converted to lower.dot.case"
     end
 
-    context 'When a string UpperCamelCase,' do
-      include_context 'UpperCamelCase'
+    context "When a string UpperCamelCase," do
+      include_context "UpperCamelCase"
 
-      it_behaves_like 'be converted to lower.dot.case'
+      it_behaves_like "be converted to lower.dot.case"
     end
 
-    context 'When a string lower_snake_case,' do
-      include_context 'lower_snake_case'
+    context "When a string lower_snake_case," do
+      include_context "lower_snake_case"
 
-      it_behaves_like 'be converted to lower.dot.case'
+      it_behaves_like "be converted to lower.dot.case"
     end
 
-    context 'When a string Upper_Snake_Case,' do
-      include_context 'Upper_Snake_Case'
+    context "When a string Upper_Snake_Case," do
+      include_context "Upper_Snake_Case"
 
-      it_behaves_like 'be converted to lower.dot.case'
+      it_behaves_like "be converted to lower.dot.case"
     end
 
-    context 'When a string lower-kebab-case,' do
-      include_context 'lower-kebab-case'
+    context "When a string lower-kebab-case," do
+      include_context "lower-kebab-case"
 
-      it_behaves_like 'be converted to lower.dot.case'
+      it_behaves_like "be converted to lower.dot.case"
     end
 
-    context 'When a string Upper-Kebab-Case,' do
-      include_context 'Upper-Kebab-Case'
+    context "When a string Upper-Kebab-Case," do
+      include_context "Upper-Kebab-Case"
 
-      it_behaves_like 'be converted to lower.dot.case'
+      it_behaves_like "be converted to lower.dot.case"
     end
 
-    context 'When a string lower space case,' do
-      include_context 'lower space case'
+    context "When a string lower space case," do
+      include_context "lower space case"
 
-      it_behaves_like 'be converted to lower.dot.case'
+      it_behaves_like "be converted to lower.dot.case"
     end
 
-    context 'When a string Upper Space Case,' do
-      include_context 'Upper Space Case'
+    context "When a string Upper Space Case," do
+      include_context "Upper Space Case"
 
-      it_behaves_like 'be converted to lower.dot.case'
+      it_behaves_like "be converted to lower.dot.case"
     end
-    context 'When a string lower.dot.case,' do
-      include_context 'lower.dot.case'
+    context "When a string lower.dot.case," do
+      include_context "lower.dot.case"
 
-      it_behaves_like 'be converted to lower.dot.case'
+      it_behaves_like "be converted to lower.dot.case"
     end
 
-    context 'When a string Upper.Dot.Case,' do
-      include_context 'Upper.Dot.Case'
+    context "When a string Upper.Dot.Case," do
+      include_context "Upper.Dot.Case"
 
-      it_behaves_like 'be converted to lower.dot.case'
+      it_behaves_like "be converted to lower.dot.case"
     end
   end
 
@@ -744,79 +744,79 @@ describe '[ Case Methods ]' do
   # ----------------------------------------------------------------------------
   # Convert to Upper.Dot.Case
   # ----------------------------------------------------------------------------
-  describe 'CONVERT TO Upper.Dot.Case ::' do
+  describe "CONVERT TO Upper.Dot.Case ::" do
     subject { string.to_udot }
 
     # Define shared examples.
     # --------------------------------------------------------------------------
-    shared_examples 'be converted to Upper.Dot.Case' do
-      it { is_expected.to eq('We.Are.Brushdown') }
+    shared_examples "be converted to Upper.Dot.Case" do
+      it { is_expected.to eq("We.Are.Brushdown") }
     end
     # --------------------------------------------------------------------------
 
-    context 'When a string has one word,' do
-      include_context 'one word'
+    context "When a string has one word," do
+      include_context "one word"
 
-      it { is_expected.to eq('String') }
+      it { is_expected.to eq("String") }
     end
 
-    context 'When a string lowerCamelCase,' do
-      include_context 'lowerCamelCase'
+    context "When a string lowerCamelCase," do
+      include_context "lowerCamelCase"
 
-      it_behaves_like 'be converted to Upper.Dot.Case'
+      it_behaves_like "be converted to Upper.Dot.Case"
     end
 
-    context 'When a string UpperCamelCase,' do
-      include_context 'UpperCamelCase'
+    context "When a string UpperCamelCase," do
+      include_context "UpperCamelCase"
 
-      it_behaves_like 'be converted to Upper.Dot.Case'
+      it_behaves_like "be converted to Upper.Dot.Case"
     end
 
-    context 'When a string lower_snake_case,' do
-      include_context 'lower_snake_case'
+    context "When a string lower_snake_case," do
+      include_context "lower_snake_case"
 
-      it_behaves_like 'be converted to Upper.Dot.Case'
+      it_behaves_like "be converted to Upper.Dot.Case"
     end
 
-    context 'When a string Upper_Snake_Case,' do
-      include_context 'Upper_Snake_Case'
+    context "When a string Upper_Snake_Case," do
+      include_context "Upper_Snake_Case"
 
-      it_behaves_like 'be converted to Upper.Dot.Case'
+      it_behaves_like "be converted to Upper.Dot.Case"
     end
 
-    context 'When a string lower-kebab-case,' do
-      include_context 'lower-kebab-case'
+    context "When a string lower-kebab-case," do
+      include_context "lower-kebab-case"
 
-      it_behaves_like 'be converted to Upper.Dot.Case'
+      it_behaves_like "be converted to Upper.Dot.Case"
     end
 
-    context 'When a string Upper-Kebab-Case,' do
-      include_context 'Upper-Kebab-Case'
+    context "When a string Upper-Kebab-Case," do
+      include_context "Upper-Kebab-Case"
 
-      it_behaves_like 'be converted to Upper.Dot.Case'
+      it_behaves_like "be converted to Upper.Dot.Case"
     end
 
-    context 'When a string lower space case,' do
-      include_context 'lower space case'
+    context "When a string lower space case," do
+      include_context "lower space case"
 
-      it_behaves_like 'be converted to Upper.Dot.Case'
+      it_behaves_like "be converted to Upper.Dot.Case"
     end
 
-    context 'When a string Upper Space Case,' do
-      include_context 'Upper Space Case'
+    context "When a string Upper Space Case," do
+      include_context "Upper Space Case"
 
-      it_behaves_like 'be converted to Upper.Dot.Case'
+      it_behaves_like "be converted to Upper.Dot.Case"
     end
-    context 'When a string lower.dot.case,' do
-      include_context 'lower.dot.case'
+    context "When a string lower.dot.case," do
+      include_context "lower.dot.case"
 
-      it_behaves_like 'be converted to Upper.Dot.Case'
+      it_behaves_like "be converted to Upper.Dot.Case"
     end
 
-    context 'When a string Upper.Dot.Case,' do
-      include_context 'Upper.Dot.Case'
+    context "When a string Upper.Dot.Case," do
+      include_context "Upper.Dot.Case"
 
-      it_behaves_like 'be converted to Upper.Dot.Case'
+      it_behaves_like "be converted to Upper.Dot.Case"
     end
   end
 
@@ -824,23 +824,23 @@ describe '[ Case Methods ]' do
   # ----------------------------------------------------------------------------
   # Split String According to Camel Case
   # ----------------------------------------------------------------------------
-  describe 'SPLIT ACCORDING TO CAMEL CASE ::' do
+  describe "SPLIT ACCORDING TO CAMEL CASE ::" do
     let(:string) { nil }
     subject { string.split_camel }
 
-    context 'When string is Upper Camel Case,' do
-      let!(:string) { 'ThisIsWord' }
-      it { is_expected.to eq(['This', 'Is', 'Word']) }
+    context "When string is Upper Camel Case," do
+      let!(:string) { "ThisIsWord" }
+      it { is_expected.to eq(["This", "Is", "Word"]) }
     end
 
-    context 'When string is Lower Camel Case,' do
-      let!(:string) { 'thisIsWord' }
-      it { is_expected.to eq(['this', 'Is', 'Word']) }
+    context "When string is Lower Camel Case," do
+      let!(:string) { "thisIsWord" }
+      it { is_expected.to eq(["this", "Is", "Word"]) }
     end
 
-    context 'When string is not Camel Case,' do
-      let!(:string) { 'thisisword' }
-      it { is_expected.to eq(['thisisword']) }
+    context "When string is not Camel Case," do
+      let!(:string) { "thisisword" }
+      it { is_expected.to eq(["thisisword"]) }
     end
   end
 
@@ -848,17 +848,17 @@ describe '[ Case Methods ]' do
   # ----------------------------------------------------------------------------
   # Check is_upper?
   # ----------------------------------------------------------------------------
-  describe 'CHECK is_upper? ::' do
+  describe "CHECK is_upper? ::" do
     let(:character) { nil }
     subject { character.is_upper? }
 
-    context 'when a character is upper case,' do
-      let(:character) { 'C' }
+    context "when a character is upper case," do
+      let(:character) { "C" }
       it { is_expected.to be true }
     end
 
-    context 'when a character is lower case,' do
-      let(:character) { 'c' }
+    context "when a character is lower case," do
+      let(:character) { "c" }
       it { is_expected.to be false }
     end
   end
@@ -867,17 +867,17 @@ describe '[ Case Methods ]' do
   # ----------------------------------------------------------------------------
   # Check is_lower?
   # ----------------------------------------------------------------------------
-  describe 'CHECK is_lower? ::' do
+  describe "CHECK is_lower? ::" do
     let(:character) { nil }
     subject { character.is_lower? }
 
-    context 'when a character is lower case,' do
-      let(:character) { 'c' }
+    context "when a character is lower case," do
+      let(:character) { "c" }
       it { is_expected.to be true }
     end
 
-    context 'when a character is uppser case,' do
-      let(:character) { 'C' }
+    context "when a character is uppser case," do
+      let(:character) { "C" }
       it { is_expected.to be false }
     end
   end
@@ -886,18 +886,18 @@ describe '[ Case Methods ]' do
   # ----------------------------------------------------------------------------
   # Make First Character Lower Case
   # ----------------------------------------------------------------------------
-  describe 'MAKE FIRST CHARACTER LOWER CASE ::' do
+  describe "MAKE FIRST CHARACTER LOWER CASE ::" do
     let(:string) { nil }
     subject { string.make_head_lower }
 
-    context 'When first character is Upper Case,' do
-      let(:string) { 'ThisIsString' }
-      it { is_expected.to eq('thisIsString') }
+    context "When first character is Upper Case," do
+      let(:string) { "ThisIsString" }
+      it { is_expected.to eq("thisIsString") }
     end
 
-    context 'When first character is Lower Case,' do
-      let(:string) { 'thisIsString' }
-      it { is_expected.to eq('thisIsString') }
+    context "When first character is Lower Case," do
+      let(:string) { "thisIsString" }
+      it { is_expected.to eq("thisIsString") }
     end
   end
 

--- a/spec/string_foundation/convert_spec.rb
+++ b/spec/string_foundation/convert_spec.rb
@@ -2,29 +2,29 @@
 # SPEC - STRING FOUNDATION - CONVERT
 # ==============================================================================
 # frozen_string_literal: true
-describe '[ Convert Methods ]' do
+describe "[ Convert Methods ]" do
 
   # ----------------------------------------------------------------------------
   # Convert To TrueClass Or FalseClass
   # ----------------------------------------------------------------------------
-  describe 'CONVERT TO TRUECLASS OR FALSE CLASS' do
+  describe "CONVERT TO TRUECLASS OR FALSE CLASS" do
     let(:string) { nil }
     subject { string.to_bool }
 
-    context 'when a string is "true",' do
-      let(:string) { 'true' }
+    context "when a string is \"true\"," do
+      let(:string) { "true" }
 
       it { is_expected.to be true }
     end
 
-    context 'when a string is "false",' do
-      let(:string) { 'false' }
+    context "when a string is \"false\"," do
+      let(:string) { "false" }
 
       it { is_expected.to be false }
     end
 
-    context 'when a string is invalid,' do
-      let(:string) { 'dummy' }
+    context "when a string is invalid," do
+      let(:string) { "dummy" }
 
       it { is_expected_as_block.to raise_error(TypeError) }
     end
@@ -34,66 +34,66 @@ describe '[ Convert Methods ]' do
   # ----------------------------------------------------------------------------
   # Convert A BOOLY STRING To TrueClass Or FalseClass
   # ----------------------------------------------------------------------------
-  describe 'CONVERT A BOOLY STRING TO TRUECLASS OR FALSE CLASS' do
+  describe "CONVERT A BOOLY STRING TO TRUECLASS OR FALSE CLASS" do
     let(:string) { nil }
     subject { string.to_booly }
 
-    context 'when a string is "true",' do
-      let(:string) { 'true' }
+    context "when a string is \"true\"," do
+      let(:string) { "true" }
 
       it { is_expected.to be true }
     end
 
-    context 'when a string is "false",' do
-      let(:string) { 'false' }
+    context "when a string is \"false\"," do
+      let(:string) { "false" }
 
       it { is_expected.to be false }
     end
 
-    context 'when a string is invalid,' do
-      let(:string) { 'dummy' }
+    context "when a string is invalid," do
+      let(:string) { "dummy" }
 
       it { is_expected_as_block.to raise_error(TypeError) }
     end
 
-    context 'when a string is a positive integral number,' do
-      let(:string) { '1' }
+    context "when a string is a positive integral number," do
+      let(:string) { "1" }
 
       it { is_expected.to be true }
     end
 
-    context 'when a string is a negative integral number,' do
-      let(:string) { '-1' }
+    context "when a string is a negative integral number," do
+      let(:string) { "-1" }
 
       it { is_expected.to be false }
     end
 
-    context 'when a string is a positive floating point number,' do
-      let(:string) { '0.1' }
+    context "when a string is a positive floating point number," do
+      let(:string) { "0.1" }
 
       it { is_expected.to be true }
     end
 
-    context 'when a string is a negative floating point number,' do
-      let(:string) { '-0.1' }
+    context "when a string is a negative floating point number," do
+      let(:string) { "-0.1" }
 
       it { is_expected.to be false }
     end
 
-    context 'when a string is 0,' do
-      let(:string) { '0' }
+    context "when a string is 0," do
+      let(:string) { "0" }
 
       it { is_expected.to be false }
     end
 
-    context 'when a string is 0.0,' do
-      let(:string) { '0.0' }
+    context "when a string is 0.0," do
+      let(:string) { "0.0" }
 
       it { is_expected.to be false }
     end
 
-    context 'when a string is an empty string,' do
-      let(:string) { '' }
+    context "when a string is an empty string," do
+      let(:string) { "" }
 
       it { is_expected.to be false }
     end
@@ -103,60 +103,60 @@ describe '[ Convert Methods ]' do
   # ----------------------------------------------------------------------------
   # Convert To Proper Class From String
   # ----------------------------------------------------------------------------
-  describe 'CONVER TO PROPER CLASS FROM STRING' do
+  describe "CONVER TO PROPER CLASS FROM STRING" do
     let(:string) { nil }
     subject { string.to_pretty }
 
-    context 'when a string is "0",' do
-      let(:string) { '0' }
+    context "when a string is \"0\"," do
+      let(:string) { "0" }
 
       it { is_expected.to eq(0) }
     end
 
-    context 'when a string is "1",' do
-      let(:string) { '1' }
+    context "when a string is \"1\"," do
+      let(:string) { "1" }
 
       it { is_expected.to eq(1) }
     end
 
-    context 'when a string is "000123",' do
-      let(:string) { '000123' }
+    context "when a string is \"000123\"," do
+      let(:string) { "000123" }
 
       it { is_expected.to eq(123) }
     end
 
-    context 'when a string is "0.0",' do
-      let(:string) { '0.0' }
+    context "when a string is \"0.0\"," do
+      let(:string) { "0.0" }
 
       it { is_expected.to eq(0.0) }
     end
 
-    context 'when a string is "000.00123",' do
-      let(:string) { '000.00123' }
+    context "when a string is \"000.00123\"," do
+      let(:string) { "000.00123" }
 
       it { is_expected.to eq(0.00123) }
     end
 
-    context 'when a string is "true",' do
-      let(:string) { 'true' }
+    context "when a string is \"true\"," do
+      let(:string) { "true" }
 
       it { is_expected.to be true }
     end
 
-    context 'when a string is "false",' do
-      let(:string) { 'false' }
+    context "when a string is \"false\"," do
+      let(:string) { "false" }
 
       it { is_expected.to be false }
     end
 
-    context 'when a string is "dummy",' do
-      let(:string) { 'dummy' }
+    context "when a string is \"dummy\"," do
+      let(:string) { "dummy" }
 
       it { is_expected.to eq(string) }
     end
 
-    context 'when a string is an empty string,' do
-      let(:string) { '' }
+    context "when a string is an empty string," do
+      let(:string) { "" }
 
       it { is_expected.to be_nil }
     end
@@ -166,43 +166,43 @@ describe '[ Convert Methods ]' do
   # ----------------------------------------------------------------------------
   # Convert From Newline To Characters
   # ----------------------------------------------------------------------------
-  describe 'CONVERT FROM NEWLINE TO CHARACTERS' do
+  describe "CONVERT FROM NEWLINE TO CHARACTERS" do
     let(:string) { "We are Brushdown.\nWe are Brushdown." }
-    let(:char) { '<br>' }
+    let(:char) { "<br>" }
     subject { string.nl_to(char) }
 
-    context 'when a string has newlines "\n",' do
-      it { is_expected.to eq('We are Brushdown.<br>We are Brushdown.') }
+    context "when a string has newlines \"\\n\"," do
+      it { is_expected.to eq("We are Brushdown.<br>We are Brushdown.") }
     end
 
-    context 'when a string has newlines "\r\n",' do
+    context "when a string has newlines \"\\r\\n\"," do
       let(:string) { "We are Brushdown.\r\nWe are Brushdown." }
 
-      it { is_expected.to eq('We are Brushdown.<br>We are Brushdown.') }
+      it { is_expected.to eq("We are Brushdown.<br>We are Brushdown.") }
     end
 
-    context 'when a string does not have newlines,' do
+    context "when a string does not have newlines," do
       let(:string) { "We are Brushdown. We are Brushdown." }
 
       it { is_expected.to eq(string) }
     end
 
-    context 'when an argument is not set,' do
+    context "when an argument is not set," do
       subject { string.nl_to() }
 
       it { is_expected_as_block.to raise_error(ArgumentError) }
     end
 
-    context 'when an argument is nil,' do
+    context "when an argument is nil," do
       let(:char) { nil }
 
-      it { is_expected.to eq('We are Brushdown.We are Brushdown.') }
+      it { is_expected.to eq("We are Brushdown.We are Brushdown.") }
     end
 
-    context 'when an argument is an empty string,' do
-      let(:char) { '' }
+    context "when an argument is an empty string," do
+      let(:char) { "" }
 
-      it { is_expected.to eq('We are Brushdown.We are Brushdown.') }
+      it { is_expected.to eq("We are Brushdown.We are Brushdown.") }
     end
   end
 
@@ -210,21 +210,21 @@ describe '[ Convert Methods ]' do
   # ----------------------------------------------------------------------------
   # Convert From Newline To <br>
   # ----------------------------------------------------------------------------
-  describe 'CONVERT FROM NEWLINE TO `<br>`' do
+  describe "CONVERT FROM NEWLINE TO `<br>`" do
     let(:string) { "We are Brushdown.\nWe are Brushdown." }
     subject { string.nl_to_br }
 
-    context 'when a string has newlines "\n",' do
-      it { is_expected.to eq('We are Brushdown.<br>We are Brushdown.') }
+    context "when a string has newlines \"\n\"," do
+      it { is_expected.to eq("We are Brushdown.<br>We are Brushdown.") }
     end
 
-    context 'when a string has newlines "\r\n",' do
+    context "when a string has newlines \"\\r\\n\"," do
       let(:string) { "We are Brushdown.\r\nWe are Brushdown." }
 
-      it { is_expected.to eq('We are Brushdown.<br>We are Brushdown.') }
+      it { is_expected.to eq("We are Brushdown.<br>We are Brushdown.") }
     end
 
-    context 'when a string does not have newlines,' do
+    context "when a string does not have newlines," do
       let(:string) { "We are Brushdown. We are Brushdown." }
 
       it { is_expected.to eq(string) }

--- a/spec/string_foundation/convertaile_spec.rb
+++ b/spec/string_foundation/convertaile_spec.rb
@@ -2,97 +2,97 @@
 # SPEC - STRING FOUNDATION - CONVERTIBLE
 # ==============================================================================
 # frozen_string_literal: true
-describe '[ Convertible Methods ]' do
+describe "[ Convertible Methods ]" do
 
   # ----------------------------------------------------------------------------
   # Check Convertible To Integer
   # ----------------------------------------------------------------------------
-  describe 'CHECK CONVERTIBLE TO INTEGER' do
+  describe "CHECK CONVERTIBLE TO INTEGER" do
     let(:string) { nil }
     subject { string.to_i? }
 
-    context 'when a string is an integral number,' do
-      context 'and it is a positive number,' do
-        let(:string) { '123' }
+    context "when a string is an integral number," do
+      context "and it is a positive number," do
+        let(:string) { "123" }
 
         it { is_expected.to be true }
       end
 
-      context 'and it is a positive number with a sign,' do
-        let(:string) { '+123' }
+      context "and it is a positive number with a sign," do
+        let(:string) { "+123" }
 
         it { is_expected.to be true }
       end
 
-      context 'and it is a negative number,' do
-        let(:string) { '-5' }
-
-        it { is_expected.to be true }
-      end
-    end
-
-    context 'when a string is a floating point number,' do
-      context 'and it is a positive number,' do
-        let(:string) { '0.123' }
-
-        it { is_expected.to be true }
-      end
-
-      context 'and it is a positive number with a sign,' do
-        let(:string) { '+0.123' }
-
-        it { is_expected.to be true }
-      end
-
-      context 'and it is a negative number,' do
-        let(:string) { '-5.123' }
+      context "and it is a negative number," do
+        let(:string) { "-5" }
 
         it { is_expected.to be true }
       end
     end
 
-    context 'when a string is a floating point number without an integer,' do
-      context 'and it is a positive number,' do
-        let(:string) { '.123' }
+    context "when a string is a floating point number," do
+      context "and it is a positive number," do
+        let(:string) { "0.123" }
 
         it { is_expected.to be true }
       end
 
-      context 'and it is a positive number with a sign,' do
-        let(:string) { '+.123' }
+      context "and it is a positive number with a sign," do
+        let(:string) { "+0.123" }
 
         it { is_expected.to be true }
       end
 
-      context 'and it is a negative number,' do
-        let(:string) { '-.123' }
-
-        it { is_expected.to be true }
-      end
-    end
-
-    context 'when a string a number has leading zeros,' do
-      context 'and it is a positive number,' do
-        let(:string) { '00000123' }
-
-        it { is_expected.to be true }
-      end
-
-      context 'and it is a positive number with a sign,' do
-        let(:string) { '+00000123' }
-
-        it { is_expected.to be true }
-      end
-
-      context 'and it is a negative number,' do
-        let(:string) { '-00000123' }
+      context "and it is a negative number," do
+        let(:string) { "-5.123" }
 
         it { is_expected.to be true }
       end
     end
 
-    context 'when a string is not a number,' do
-      let(:string) { 'abc' }
+    context "when a string is a floating point number without an integer," do
+      context "and it is a positive number," do
+        let(:string) { ".123" }
+
+        it { is_expected.to be true }
+      end
+
+      context "and it is a positive number with a sign," do
+        let(:string) { "+.123" }
+
+        it { is_expected.to be true }
+      end
+
+      context "and it is a negative number," do
+        let(:string) { "-.123" }
+
+        it { is_expected.to be true }
+      end
+    end
+
+    context "when a string a number has leading zeros," do
+      context "and it is a positive number," do
+        let(:string) { "00000123" }
+
+        it { is_expected.to be true }
+      end
+
+      context "and it is a positive number with a sign," do
+        let(:string) { "+00000123" }
+
+        it { is_expected.to be true }
+      end
+
+      context "and it is a negative number," do
+        let(:string) { "-00000123" }
+
+        it { is_expected.to be true }
+      end
+    end
+
+    context "when a string is not a number," do
+      let(:string) { "abc" }
 
       it { is_expected.to be false }
     end
@@ -102,92 +102,92 @@ describe '[ Convertible Methods ]' do
   # ----------------------------------------------------------------------------
   # Check Convertible To Float
   # ----------------------------------------------------------------------------
-  describe 'CHECK CONVERTIBLE TO FLOAT' do
+  describe "CHECK CONVERTIBLE TO FLOAT" do
     let(:string) { nil }
     subject { string.to_f? }
 
-    context 'when a string is an integral number,' do
-      context 'and it is a positive number,' do
-        let(:string) { '123' }
+    context "when a string is an integral number," do
+      context "and it is a positive number," do
+        let(:string) { "123" }
 
         it { is_expected.to be true }
       end
 
-      context 'and it is a positive number with a sign,' do
-        let(:string) { '+123' }
+      context "and it is a positive number with a sign," do
+        let(:string) { "+123" }
 
         it { is_expected.to be true }
       end
 
-      context 'and it is a negative number,' do
-        let(:string) { '-5' }
-
-        it { is_expected.to be true }
-      end
-    end
-
-    context 'when a string is a floating point number,' do
-      context 'and it is a positive number,' do
-        let(:string) { '0.123' }
-
-        it { is_expected.to be true }
-      end
-
-      context 'and it is a positive number with a sign,' do
-        let(:string) { '+0.123' }
-
-        it { is_expected.to be true }
-      end
-
-      context 'and it is a negative number,' do
-        let(:string) { '-5.123' }
+      context "and it is a negative number," do
+        let(:string) { "-5" }
 
         it { is_expected.to be true }
       end
     end
 
-    context 'when a string is a floating point number without an integer,' do
-      context 'and it is a positive number,' do
-        let(:string) { '.123' }
+    context "when a string is a floating point number," do
+      context "and it is a positive number," do
+        let(:string) { "0.123" }
 
         it { is_expected.to be true }
       end
 
-      context 'and it is a positive number with a sign,' do
-        let(:string) { '+.123' }
+      context "and it is a positive number with a sign," do
+        let(:string) { "+0.123" }
 
         it { is_expected.to be true }
       end
 
-      context 'and it is a negative number,' do
-        let(:string) { '-.123' }
-
-        it { is_expected.to be true }
-      end
-    end
-
-    context 'when a string a number has leading zeros,' do
-      context 'and it is a positive number,' do
-        let(:string) { '00000123' }
-
-        it { is_expected.to be true }
-      end
-
-      context 'and it is a positive number with a sign,' do
-        let(:string) { '+00000123' }
-
-        it { is_expected.to be true }
-      end
-
-      context 'and it is a negative number,' do
-        let(:string) { '-00000123' }
+      context "and it is a negative number," do
+        let(:string) { "-5.123" }
 
         it { is_expected.to be true }
       end
     end
 
-    context 'when a string is not a number,' do
-      let(:string) { 'abc' }
+    context "when a string is a floating point number without an integer," do
+      context "and it is a positive number," do
+        let(:string) { ".123" }
+
+        it { is_expected.to be true }
+      end
+
+      context "and it is a positive number with a sign," do
+        let(:string) { "+.123" }
+
+        it { is_expected.to be true }
+      end
+
+      context "and it is a negative number," do
+        let(:string) { "-.123" }
+
+        it { is_expected.to be true }
+      end
+    end
+
+    context "when a string a number has leading zeros," do
+      context "and it is a positive number," do
+        let(:string) { "00000123" }
+
+        it { is_expected.to be true }
+      end
+
+      context "and it is a positive number with a sign," do
+        let(:string) { "+00000123" }
+
+        it { is_expected.to be true }
+      end
+
+      context "and it is a negative number," do
+        let(:string) { "-00000123" }
+
+        it { is_expected.to be true }
+      end
+    end
+
+    context "when a string is not a number," do
+      let(:string) { "abc" }
 
       it { is_expected.to be false }
     end
@@ -197,42 +197,42 @@ describe '[ Convertible Methods ]' do
   # ----------------------------------------------------------------------------
   # Check Convertible To Boolean
   # ----------------------------------------------------------------------------
-  describe 'CHECK CONVERTIBLE TO BOOLEAN' do
+  describe "CHECK CONVERTIBLE TO BOOLEAN" do
     let(:string) { nil }
     subject { string.to_bool? }
 
-    context 'when a string is "true",' do
-      let(:string) { 'true' }
+    context "when a string is \"true\"," do
+      let(:string) { "true" }
 
       it { is_expected.to be true }
     end
 
-    context 'when a string is "false",' do
-      let(:string) { 'false' }
+    context "when a string is \"false\"," do
+      let(:string) { "false" }
 
       it { is_expected.to be true }
     end
 
-    context 'when a string is an empty,' do
-      let(:string) { '' }
+    context "when a string is an empty," do
+      let(:string) { "" }
 
       it { is_expected.to be false }
     end
 
-    context 'when a string is a positive number,' do
-      let(:string) { '1' }
+    context "when a string is a positive number," do
+      let(:string) { "1" }
 
       it { is_expected.to be false }
     end
 
-    context 'when a string is a negative number,' do
-      let(:string) { '-1' }
+    context "when a string is a negative number," do
+      let(:string) { "-1" }
 
       it { is_expected.to be false }
     end
 
-    context 'when a string is not a number,' do
-      let(:string) { 'abc' }
+    context "when a string is not a number," do
+      let(:string) { "abc" }
 
       it { is_expected.to be false }
     end
@@ -242,42 +242,42 @@ describe '[ Convertible Methods ]' do
   # ----------------------------------------------------------------------------
   # Check Convertaile To Booly
   # ----------------------------------------------------------------------------
-  describe 'CHECK CONVERTIBLE TO BOOLYs' do
+  describe "CHECK CONVERTIBLE TO BOOLYs" do
     let(:string) { nil }
     subject { string.to_booly? }
 
-    context 'when a string is "true",' do
-      let(:string) { 'true' }
+    context "when a string is \"true\"," do
+      let(:string) { "true" }
 
       it { is_expected.to be true }
     end
 
-    context 'when a string is "false",' do
-      let(:string) { 'false' }
+    context "when a string is \"false\"," do
+      let(:string) { "false" }
 
       it { is_expected.to be true }
     end
 
-    context 'when a string is an empty,' do
-      let(:string) { '' }
+    context "when a string is an empty," do
+      let(:string) { "" }
 
       it { is_expected.to be true }
     end
 
-    context 'when a string is a positive number,' do
-      let(:string) { '1' }
+    context "when a string is a positive number," do
+      let(:string) { "1" }
 
       it { is_expected.to be true }
     end
 
-    context 'when a string is a negative number,' do
-      let(:string) { '-1' }
+    context "when a string is a negative number," do
+      let(:string) { "-1" }
 
       it { is_expected.to be true }
     end
 
-    context 'when a string is not a number,' do
-      let(:string) { 'abc' }
+    context "when a string is not a number," do
+      let(:string) { "abc" }
 
       it { is_expected.to be false }
     end

--- a/spec/string_foundation/like_spec.rb
+++ b/spec/string_foundation/like_spec.rb
@@ -2,109 +2,109 @@
 # SPEC - STRING FOUNDATION - LIKE
 # ==============================================================================
 # frozen_string_literal: true
-describe '[ Like Methods ]' do
+describe "[ Like Methods ]" do
 
   # ----------------------------------------------------------------------------
   # Check Whether A String Is Integer
   # ----------------------------------------------------------------------------
-  describe 'CHECK WHETHER A STRING IS INTEGER ::' do
+  describe "CHECK WHETHER A STRING IS INTEGER ::" do
     let(:string) { nil }
     subject { string.like_i? }
 
-    context 'when a string is an integral number,' do
-      context 'and it is a positive number,' do
-        let(:string) { '123' }
+    context "when a string is an integral number," do
+      context "and it is a positive number," do
+        let(:string) { "123" }
 
         it { is_expected.to be true }
       end
 
-      context 'and it is a positive number with a sign,' do
-        let(:string) { '+123' }
+      context "and it is a positive number with a sign," do
+        let(:string) { "+123" }
 
         it { is_expected.to be true }
       end
 
-      context 'and it is a negative number,' do
-        let(:string) { '-5' }
-
-        it { is_expected.to be true }
-      end
-    end
-
-    context 'when a string is a floating point number,' do
-      context 'and it is a positive number,' do
-        let(:string) { '0.123' }
-
-        it { is_expected.to be false }
-      end
-
-      context 'and it is a positive number with a sign,' do
-        let(:string) { '+0.123' }
-
-        it { is_expected.to be false }
-      end
-
-      context 'and it is a negative number,' do
-        let(:string) { '-5.123' }
-
-        it { is_expected.to be false }
-      end
-    end
-
-    context 'when a string is a floating point number without an integer,' do
-      context 'and it is a positive number,' do
-        let(:string) { '.123' }
-
-        it { is_expected.to be false }
-      end
-
-      context 'and it is a positive number with a sign,' do
-        let(:string) { '+.123' }
-
-        it { is_expected.to be false }
-      end
-
-      context 'and it is a negative number,' do
-        let(:string) { '-.123' }
-
-        it { is_expected.to be false }
-      end
-    end
-
-    context 'when a string a number has leading zeros,' do
-      context 'and it is a positive number,' do
-        let(:string) { '00000123' }
-
-        it { is_expected.to be true }
-      end
-
-      context 'and it is a positive number with a sign,' do
-        let(:string) { '+00000123' }
-
-        it { is_expected.to be true }
-      end
-
-      context 'and it is a negative number,' do
-        let(:string) { '-00000123' }
+      context "and it is a negative number," do
+        let(:string) { "-5" }
 
         it { is_expected.to be true }
       end
     end
 
-    context 'when a string is 0,' do
-      let(:string) { '0' }
+    context "when a string is a floating point number," do
+      context "and it is a positive number," do
+        let(:string) { "0.123" }
+
+        it { is_expected.to be false }
+      end
+
+      context "and it is a positive number with a sign," do
+        let(:string) { "+0.123" }
+
+        it { is_expected.to be false }
+      end
+
+      context "and it is a negative number," do
+        let(:string) { "-5.123" }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context "when a string is a floating point number without an integer," do
+      context "and it is a positive number," do
+        let(:string) { ".123" }
+
+        it { is_expected.to be false }
+      end
+
+      context "and it is a positive number with a sign," do
+        let(:string) { "+.123" }
+
+        it { is_expected.to be false }
+      end
+
+      context "and it is a negative number," do
+        let(:string) { "-.123" }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context "when a string a number has leading zeros," do
+      context "and it is a positive number," do
+        let(:string) { "00000123" }
+
+        it { is_expected.to be true }
+      end
+
+      context "and it is a positive number with a sign," do
+        let(:string) { "+00000123" }
+
+        it { is_expected.to be true }
+      end
+
+      context "and it is a negative number," do
+        let(:string) { "-00000123" }
+
+        it { is_expected.to be true }
+      end
+    end
+
+    context "when a string is 0," do
+      let(:string) { "0" }
 
       it { is_expected.to be true }
     end
 
-    context 'when a string is 0.0,' do
-      let(:string) { '0.0' }
+    context "when a string is 0.0," do
+      let(:string) { "0.0" }
 
       it { is_expected.to be false }
     end
 
-    context 'when a string is not a number,' do
-      let(:string) { 'abc' }
+    context "when a string is not a number," do
+      let(:string) { "abc" }
 
       it { is_expected.to be false }
     end
@@ -113,104 +113,104 @@ describe '[ Like Methods ]' do
   # ----------------------------------------------------------------------------
   # Check Whether A String Is Float
   # ----------------------------------------------------------------------------
-  describe 'CHECK WHETHER A STRING IS FLOAT ::' do
+  describe "CHECK WHETHER A STRING IS FLOAT ::" do
     let(:string) { nil }
     subject { string.like_f? }
 
-    context 'when a string is an integral number,' do
-      context 'and it is a positive number,' do
-        let(:string) { '123' }
+    context "when a string is an integral number," do
+      context "and it is a positive number," do
+        let(:string) { "123" }
 
         it { is_expected.to be false }
       end
 
-      context 'and it is a positive number with a sign,' do
-        let(:string) { '+123' }
+      context "and it is a positive number with a sign," do
+        let(:string) { "+123" }
 
         it { is_expected.to be false }
       end
 
-      context 'and it is a negative number,' do
-        let(:string) { '-5' }
-
-        it { is_expected.to be false }
-      end
-    end
-
-    context 'when a string is a floating point number,' do
-      context 'and it is a positive number,' do
-        let(:string) { '0.123' }
-
-        it { is_expected.to be true }
-      end
-
-      context 'and it is a positive number with a sign,' do
-        let(:string) { '+0.123' }
-
-        it { is_expected.to be true }
-      end
-
-      context 'and it is a negative number,' do
-        let(:string) { '-5.123' }
-
-        it { is_expected.to be true }
-      end
-    end
-
-    context 'when a string is a floating point number without an integer,' do
-      context 'and it is a positive number,' do
-        let(:string) { '.123' }
-
-        it { is_expected.to be true }
-      end
-
-      context 'and it is a positive number with a sign,' do
-        let(:string) { '+.123' }
-
-        it { is_expected.to be true }
-      end
-
-      context 'and it is a negative number,' do
-        let(:string) { '-.123' }
-
-        it { is_expected.to be true }
-      end
-    end
-
-    context 'when a string a number has leading zeros,' do
-      context 'and it is a positive number,' do
-        let(:string) { '00000123' }
-
-        it { is_expected.to be false }
-      end
-
-      context 'and it is a positive number with a sign,' do
-        let(:string) { '+00000123' }
-
-        it { is_expected.to be false }
-      end
-
-      context 'and it is a negative number,' do
-        let(:string) { '-00000123' }
+      context "and it is a negative number," do
+        let(:string) { "-5" }
 
         it { is_expected.to be false }
       end
     end
 
-    context 'when a string is 0,' do
-      let(:string) { '0' }
+    context "when a string is a floating point number," do
+      context "and it is a positive number," do
+        let(:string) { "0.123" }
+
+        it { is_expected.to be true }
+      end
+
+      context "and it is a positive number with a sign," do
+        let(:string) { "+0.123" }
+
+        it { is_expected.to be true }
+      end
+
+      context "and it is a negative number," do
+        let(:string) { "-5.123" }
+
+        it { is_expected.to be true }
+      end
+    end
+
+    context "when a string is a floating point number without an integer," do
+      context "and it is a positive number," do
+        let(:string) { ".123" }
+
+        it { is_expected.to be true }
+      end
+
+      context "and it is a positive number with a sign," do
+        let(:string) { "+.123" }
+
+        it { is_expected.to be true }
+      end
+
+      context "and it is a negative number," do
+        let(:string) { "-.123" }
+
+        it { is_expected.to be true }
+      end
+    end
+
+    context "when a string a number has leading zeros," do
+      context "and it is a positive number," do
+        let(:string) { "00000123" }
+
+        it { is_expected.to be false }
+      end
+
+      context "and it is a positive number with a sign," do
+        let(:string) { "+00000123" }
+
+        it { is_expected.to be false }
+      end
+
+      context "and it is a negative number," do
+        let(:string) { "-00000123" }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context "when a string is 0," do
+      let(:string) { "0" }
 
       it { is_expected.to be false }
     end
 
-    context 'when a string is 0.0,' do
-      let(:string) { '0.0' }
+    context "when a string is 0.0," do
+      let(:string) { "0.0" }
 
       it { is_expected.to be true }
     end
 
-    context 'when a string is not a number,' do
-      let(:string) { 'abc' }
+    context "when a string is not a number," do
+      let(:string) { "abc" }
 
       it { is_expected.to be false }
     end

--- a/spec/string_foundation/version_spec.rb
+++ b/spec/string_foundation/version_spec.rb
@@ -7,7 +7,7 @@ describe StringFoundation::VERSION do
   # ----------------------------------------------------------------------------
   # Version Definition
   # ----------------------------------------------------------------------------
-  it 'should have a version number' do
+  it "should have a version number" do
     expect(StringFoundation::VERSION).not_to be_nil
   end
 

--- a/spec/string_foundation/with_spec.rb
+++ b/spec/string_foundation/with_spec.rb
@@ -2,94 +2,94 @@
 # SPEC - STRING FOUNDATION - VERSION
 # ==============================================================================
 # frozen_string_literal: true
-describe '[ With Methods ]' do
+describe "[ With Methods ]" do
 
   # ----------------------------------------------------------------------------
   # Without Leading Zeros
   # ----------------------------------------------------------------------------
-  describe 'WITHOUT LEADING ZEROS ::' do
+  describe "WITHOUT LEADING ZEROS ::" do
     let(:string_number) { nil }
     subject { string_number.without_leading_zeros }
 
-    context 'when a string has leading zeros,' do
-      context 'without a plus or minus sign,' do
-        let(:string_number) { '0000123' }
+    context "when a string has leading zeros," do
+      context "without a plus or minus sign," do
+        let(:string_number) { "0000123" }
 
-        it { is_expected.to eq('123') }
+        it { is_expected.to eq("123") }
       end
 
-      context 'with a minus sign,' do
-        let(:string_number) { '-0000123' }
+      context "with a minus sign," do
+        let(:string_number) { "-0000123" }
 
-        it { is_expected.to eq('-123') }
-      end
-    end
-
-    context 'when a string has some zero characters,' do
-      context 'without a plus or minus sign,' do
-        let(:string_number) { '00001230000' }
-
-        it { is_expected.to eq('1230000') }
-      end
-
-
-      context 'with a minus sign,' do
-        let(:string_number) { '-00001230000' }
-
-        it { is_expected.to eq('-1230000') }
+        it { is_expected.to eq("-123") }
       end
     end
 
-    context 'when a string like a floating point number has leading zeros,' do
-      context 'without a plus or minus sign,' do
-        let(:string_number) { '000000.3' }
+    context "when a string has some zero characters," do
+      context "without a plus or minus sign," do
+        let(:string_number) { "00001230000" }
 
-        it { is_expected.to eq('0.3') }
+        it { is_expected.to eq("1230000") }
       end
 
-      context 'with a minus sign,' do
-        let(:string_number) { '-000000.3' }
 
-        it { is_expected.to eq('-0.3') }
-      end
-    end
+      context "with a minus sign," do
+        let(:string_number) { "-00001230000" }
 
-    context 'when a string is "0",' do
-      context 'without a plus or minus sign,' do
-        let(:string_number) { '0' }
-
-        it { is_expected.to eq('0') }
-      end
-
-      context 'with a minus sign,' do
-        let(:string_number) { '-0' }
-
-        it { is_expected.to eq('0') }
+        it { is_expected.to eq("-1230000") }
       end
     end
 
-    context 'when a string has only zero characters,' do
-      context 'without a plus or minus sign,' do
-        it 'should return a string "0"' do
-          expect('00'.without_leading_zeros).to eq('0')
-          expect('000'.without_leading_zeros).to eq('0')
-          expect('0000'.without_leading_zeros).to eq('0')
-          expect('00000'.without_leading_zeros).to eq('0')
+    context "when a string like a floating point number has leading zeros," do
+      context "without a plus or minus sign," do
+        let(:string_number) { "000000.3" }
+
+        it { is_expected.to eq("0.3") }
+      end
+
+      context "with a minus sign," do
+        let(:string_number) { "-000000.3" }
+
+        it { is_expected.to eq("-0.3") }
+      end
+    end
+
+    context "when a string is \"0\"," do
+      context "without a plus or minus sign," do
+        let(:string_number) { "0" }
+
+        it { is_expected.to eq("0") }
+      end
+
+      context "with a minus sign," do
+        let(:string_number) { "-0" }
+
+        it { is_expected.to eq("0") }
+      end
+    end
+
+    context "when a string has only zero characters," do
+      context "without a plus or minus sign," do
+        it "should return a string \"0\"" do
+          expect("00".without_leading_zeros).to eq("0")
+          expect("000".without_leading_zeros).to eq("0")
+          expect("0000".without_leading_zeros).to eq("0")
+          expect("00000".without_leading_zeros).to eq("0")
         end
       end
 
-      context 'with a minus sign,' do
-        it 'should return a string "0"' do
-          expect('-00'.without_leading_zeros).to eq('0')
-          expect('-000'.without_leading_zeros).to eq('0')
-          expect('-0000'.without_leading_zeros).to eq('0')
-          expect('-00000'.without_leading_zeros).to eq('0')
+      context "with a minus sign," do
+        it "should return a string \"0\"" do
+          expect("-00".without_leading_zeros).to eq("0")
+          expect("-000".without_leading_zeros).to eq("0")
+          expect("-0000".without_leading_zeros).to eq("0")
+          expect("-00000".without_leading_zeros).to eq("0")
         end
       end
     end
 
-    context 'when a string does not start with "0" and "-0",' do
-      it 'should return the same string' do
+    context "when a string does not start with \"0\" and \"-0\"," do
+      it "should return the same string" do
         random_text = RandomToken.gen(10, seed: :alphabet).without_leading_zeros
         expect(random_text).to eq(random_text)
       end

--- a/string_foundation.gemspec
+++ b/string_foundation.gemspec
@@ -3,21 +3,21 @@
 # ==============================================================================
 # frozen_string_literal: true
 $:.push File.expand_path("../lib", __FILE__)
-require 'string_foundation/version'
+require "string_foundation/version"
 
 Gem::Specification.new do |spec|
-  spec.name                  = 'string_foundation'
+  spec.name                  = "string_foundation"
   spec.version               = StringFoundation::VERSION
   spec.platform              = Gem::Platform::RUBY
-  spec.authors               = ['Brushdown']
-  spec.email                 = ['dev@brushdown.com']
-  spec.homepage              = 'https://github.com/brushdown/string_foundation.rb'
-  spec.summary               = 'A library that extends Ruby string class.'
-  spec.description           = 'String Foundation is a Ruby library that provides useful methods for the Ruby string class.'
-  spec.required_ruby_version = '>= 2.1.0'
-  spec.license               = 'MIT'
+  spec.authors               = ["Brushdown"]
+  spec.email                 = ["dev@brushdown.com"]
+  spec.homepage              = "https://github.com/brushdown/string_foundation.rb"
+  spec.summary               = "A library that extends Ruby string class."
+  spec.description           = "String Foundation is a Ruby library that provides useful methods for the Ruby string class."
+  spec.required_ruby_version = ">= 2.1.0"
+  spec.license               = "MIT"
 
-  spec.files         = Dir['**/*'].keep_if { |file| File.file?(file) }
-  spec.test_files    = Dir['spec/**/*']
-  spec.require_paths = ['lib']
+  spec.files         = Dir["**/*"].keep_if { |file| File.file?(file) }
+  spec.test_files    = Dir["spec/**/*"]
+  spec.require_paths = ["lib"]
 end


### PR DESCRIPTION
- Use double quotation mark instead of single because of be less differences of other language syntax (#28)
